### PR TITLE
Download playlists

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2676,6 +2676,9 @@ def down_plist(dltype, parturl):
     title = g.pafy_pls[parturl]['title']
     subdir = mswinfn(title.replace("/", "-"))
     down_many(dltype, "1-", subdir=subdir)
+    msg = g.message
+    plist(parturl, page=0, splash=True)
+    g.message = msg
 
 
 def down_user_pls(dltype, user):


### PR DESCRIPTION
Fix for issue #294.

  * buffer entire playlist in `plist` when flag `dumps` is set. Limitation of displayed items is moved to `generate_songlist`.
  * After playlist download, `plist` is called again without `dumps` flag set, in order to re-enter browsing mode. This (27e1363) leads to some commands executed twice, but works well.