### PR TITLE
Changed the mplayer version regex

### DIFF
--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -54,7 +54,7 @@ def get_mpv_version(exename):
 
 def get_mplayer_version(exename):
     o = subprocess.check_output([exename]).decode()
-    m = re.search('^MPlayer SVN-r([0-9]+) ', o, re.MULTILINE)
+    m = re.search('^MPlayer SVN[\s-]r([0-9]+)', o, re.MULTILINE|re.IGNORECASE)
 
     ver = 0
     if m:


### PR DESCRIPTION
Changed the mplayer version regex so that the following two Mplayer version strings match successfully

`MPlayer svn r34540 (Debian), built with gcc-4.7 (C) 2000-2012 MPlayer Team`
`MPlayer SVN-r37391-5.1.1 (C) 2000-2015 MPlayer Team`

Version strings are from distro-packaged mplayer on Debian 8 and Fedora 22, respectively.