### PR TITLE
Made -v play option force video as configured

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -1265,7 +1265,7 @@ def generate_real_playerargs(song, override, failcount):
     # pylint: disable=R0914
     # pylint: disable=R0912
     video = Config.SHOW_VIDEO.get
-    video = True if override in ("fullscreen", "window") else video
+    video = True if override in ("fullscreen", "window", "forcevid") else video
     video = False if override == "audio" else video
     m4a = "mplayer" not in Config.PLAYER.get
     q, audio, cached = failcount, not video, g.streams[song.ytid]
@@ -2670,15 +2670,20 @@ def play(pre, choice, post=""):
         repeat = "repeat" in pre + post
         novid = "-a" in pre + post
         fs = "-f" in pre + post
-        nofs = "-w" in pre + post or "-v" in pre + post
+        nofs = "-w" in pre + post
+        forcevid = "-v" in pre + post
 
-        if (novid and fs) or (novid and nofs) or (nofs and fs):
+        if ((novid and fs) or (novid and nofs) or (nofs and fs)
+           or (novid and forcevid)):
             raise IOError("Conflicting override options specified")
 
         override = False
         override = "audio" if novid else override
         override = "fullscreen" if fs else override
         override = "window" if nofs else override
+
+        if (not fs) and (not nofs):
+            override = "forcevid" if forcevid else override
 
         selection = _parse_multi(choice)
         songlist = [g.model.songs[x - 1] for x in selection]
@@ -2737,7 +2742,7 @@ def preload(song, delay=2, override=False):
     g.preloading.append(ytid)
     time.sleep(delay)
     video = Config.SHOW_VIDEO.get
-    video = True if override in ("fullscreen", "window") else video
+    video = True if override in ("fullscreen", "window", "forcevid") else video
     video = False if override == "audio" else video
 
     try:


### PR DESCRIPTION
-v used to do the same as -w which was a bit awkward.
-v now forces video playback according to the options set in the config
and still gives precedence to the -w and -f options