### PR TITLE
allowed to specify youtube-dl options from mps-yt

### DIFF
--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -361,7 +361,6 @@ class _Config(object):
             ConfigItem("download_command", ''),
             ConfigItem("api_key", "AIzaSyCIM4EzNqi1in22f4Z3Ru3iYvLaY8tc3bo",
                 check_fn=check_api_key),
-            ConfigItem("yt_dl_use_https", False, check_fn=update_use_https),
             ConfigItem("yt_dl_cmdline", fake_string("<empty>",{}),
                 check_fn=check_ydl_opts_valid),
             ]

--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -1,5 +1,6 @@
 import os
 import re
+import ast
 import copy
 import pickle
 import collections
@@ -230,19 +231,17 @@ def check_being_dict(user_dict):
     """ check if user string is correct dict, set it to global options,
         since pafy accepts ydl_opts dict as ctor argument. """
     try:
-        import ast
-    except ImportError:
-        m = "Your Python is too old. Use at least 2.4 to use this option."
-        return dict(valid=False, message=m)
-    try:
         dict_ = ast.literal_eval(str(user_dict))
     except ValueError:
         m = "Entered string has wrong syntax. Usage: {'option': value}"
         return dict(valid=False, message=m)
     if isinstance(dict_, dict):
-        # it is assumed that user setting this option knows youtube-dl options
-        # names (like:quiet, prefer_insecure, no_warnings, etc)
-        g.ydl_opts = dict_
+        # to prevent overriding youtube-dl "quiet" and "no_warning" options
+        # g.ydl_opts = (dict_.update(g.ydl_opts))
+        # to allow overriding with anything user throws into setting
+        g.ydl_opts.update(dict_)
+        # to 'disable' option, one would need to pass {'option':None}
+        g.ydl_opts = {key: val for key, val in g.ydl_opts.items() if val}
         return dict(valid=True, message="Youtube-dl options set successfully")
     #elif isinstance(dict_, bool):
     # single could be set items like this, if check_fn passed 'key' as well

--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -246,11 +246,11 @@ def check_being_dict(user_dict):
         return dict(valid=True, message="Youtube-dl options set successfully")
     #elif isinstance(dict_, bool):
     # single could be set items like this, if check_fn passed 'key' as well
-    #    g.yt_dl.update({key_from_check_fn: dict_})
+    #    g.yt_dl.update({"key_from_check_fn": dict_})
     #    m = "Youtube-dl:%s option set successfully"
-    #    return dict(valid=True, message=m % (key))
+    #    return dict("valid"=True, "message"=m % (key))
     else:
-        return {valid: False, message: "Can't convert string to proper dict."}
+        return dict(valid=False, message="Can't convert string to proper dict.")
 
 def update_use_https(option):
     """ Updates single hardcoded option in dict in global config module 'g'."""

--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -227,36 +227,61 @@ def check_win_size(size):
     else:
         return dict(valid=True, value=size)
 
-def check_being_dict(user_dict):
+class fake_string(object):
+    """ this class contains string and dictionary. String is shown in config,
+        and dictionary is used behind the scenes. If pure dict was used, config
+        display would become cluttered as yt-downloader has lots of options """
+    def __init__(self, display, vals):
+        self.display = display
+        self.values = vals
+    def __getstate__(self):
+        return self.display, self.values
+    def __setstate__(self, savegame):
+        score, lives_left = savegame
+        self.display = score
+        self.values = lives_left
+    def __str__(self):
+        return self.display
+
+def check_ydl_opts_valid(user_str):
     """ check if user string is correct dict, set it to global options,
         since pafy accepts ydl_opts dict as ctor argument. """
-    try:
-        dict_ = ast.literal_eval(str(user_dict))
-    except ValueError:
-        m = "Entered string has wrong syntax. Usage: {'option': value}"
-        return dict(valid=False, message=m)
-    if isinstance(dict_, dict):
-        # to prevent overriding youtube-dl "quiet" and "no_warning" options
-        # g.ydl_opts = (dict_.update(g.ydl_opts))
-        # to allow overriding with anything user throws into setting
-        g.ydl_opts.update(dict_)
-        # to 'disable' option, one would need to pass {'option':None}
-        g.ydl_opts = {key: val for key, val in g.ydl_opts.items() if val}
-        return dict(valid=True, message="Youtube-dl options set successfully")
-    #elif isinstance(dict_, bool):
-    # single could be set items like this, if check_fn passed 'key' as well
-    #    g.yt_dl.update({"key_from_check_fn": dict_})
-    #    m = "Youtube-dl:%s option set successfully"
-    #    return dict("valid"=True, "message"=m % (key))
-    else:
-        return dict(valid=False, message="Can't convert string to proper dict.")
+    from youtube_dl.options import parseOpts
+    from optparse import BadOptionError
+    # update default options, as we intend to use them as dict later on,
+    # and pafy is supposed to pass that dict to yt-downloader constructor.
+    # parseOpts is optparse instance,
+    # returning (optparse.OptionParser, optparse.Values) tuple.
+    # optparse is funny and raises two exceptions, so both need to be caught
 
-def update_use_https(option):
-    """ Updates single hardcoded option in dict in global config module 'g'."""
-    # Ydl calls option 'prefer_insecure', but this breaks current layout of
-    # mps-yt, so was replaced by shorter 'use_https'. Caution: inversed logic
-    g.ydl_opts.update({"prefer_insecure": not option})
-    return dict(valid=True, message="yt_dl:use_https option set successfully")
+    ok_msg = c.g + "Youtube-dl options parsed, and set successfully" + c.w
+    fail = c.r + "Entered string has wrong syntax. Pass options: " + c.w
+    optp_msg = "\n- as You would to Youtube-dl from command line or"
+    dict_msg = "\n-{'option': value}"
+
+    if not user_str:
+        empty = fake_string("", {})
+        return dict(valid=True, message=ok_msg, value=empty)
+    try:
+        _, parsed_opts = parseOpts(user_str.split())
+        new = fake_string(user_str, vars(parsed_opts))
+        g.ydl_opts.update(new.values)
+        return dict(valid=True, message=ok_msg, value=new)
+    except (SystemExit, BadOptionError):
+        pass
+
+    # since there are some options that store_true only, yet some might want
+    # to change => i.e prefer_insecure; we need to check if user_str is dict
+    try:
+        dict_ = ast.literal_eval(str(user_str))
+        if isinstance(dict_, dict):
+            g.ydl_opts.update(dict_)
+        old = fake_string(str(g.ydl_opts), g.ydl_opts)
+        return dict(valid=True, message=ok_msg, value=old)
+    except ValueError:
+        # not proper ydl_opts cmdline and not a proper dict - fail
+        fail_msg = fail + optp_msg + dict_msg
+        return dict(valid=False, message=fail_msg)
 
 def check_encoder(option):
     """ Check encoder value is acceptable. """
@@ -337,7 +362,8 @@ class _Config(object):
             ConfigItem("api_key", "AIzaSyCIM4EzNqi1in22f4Z3Ru3iYvLaY8tc3bo",
                 check_fn=check_api_key),
             ConfigItem("yt_dl_use_https", False, check_fn=update_use_https),
-            ConfigItem("yt_dl_cmdline", "", check_fn=check_being_dict),
+            ConfigItem("yt_dl_cmdline", fake_string("<empty>",{}),
+                check_fn=check_ydl_opts_valid),
             ]
 
     def __getitem__(self, key):

--- a/mps_youtube/g.py
+++ b/mps_youtube/g.py
@@ -70,6 +70,7 @@ playerargs_defaults = {
         "geo": "-geometry"}
     }
 argument_commands = []
+ydl_opts = {}
 
 text = {
     "exitmsg": ("**0mps-youtube - **1http://github.com/np1/mps-youtube**0"

--- a/mps_youtube/g.py
+++ b/mps_youtube/g.py
@@ -70,7 +70,7 @@ playerargs_defaults = {
         "geo": "-geometry"}
     }
 argument_commands = []
-ydl_opts = {}
+ydl_opts = {"quiet": True, "no_warnings": True}
 
 text = {
     "exitmsg": ("**0mps-youtube - **1http://github.com/np1/mps-youtube**0"

--- a/mps_youtube/g.py
+++ b/mps_youtube/g.py
@@ -71,6 +71,7 @@ playerargs_defaults = {
     }
 argument_commands = []
 ydl_opts = {"quiet": True, "no_warnings": True}
+global_opts_were_already_updated_from_cfg = False
 
 text = {
     "exitmsg": ("**0mps-youtube - **1http://github.com/np1/mps-youtube**0"

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -188,8 +188,9 @@ def helptext():
     {2}set player <player app>{1} - use <player app> for playback
     {2}set playerargs <args>{1} - use specified arguments with player
     {2}set search_music true|false{1} - search only music (all categories if false)
-    {2}set yt_dl_use_https true|false{1} - prefer only secure connections (https)
     {2}set yt_dl_cmdline <Python dict format>{1} - initial arguments pased to youtube-dl
+    {2}set yt_dl_cmdline <youtube-dl cmdline or Python dict format>{1} - initial arguments
+        pased to youtube-dl
     {2}set show_mplayer_keys true|false{1} - show keyboard help for mplayer and mpv
     {2}set show_status true|false{1} - show status messages and progress
     {2}set show_video true|false{1} - show video output (audio only if false)

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -188,6 +188,8 @@ def helptext():
     {2}set player <player app>{1} - use <player app> for playback
     {2}set playerargs <args>{1} - use specified arguments with player
     {2}set search_music true|false{1} - search only music (all categories if false)
+    {2}set yt_dl_use_https true|false{1} - prefer only secure connections (https)
+    {2}set yt_dl_cmdline <Python dict format>{1} - initial arguments pased to youtube-dl
     {2}set show_mplayer_keys true|false{1} - show keyboard help for mplayer and mpv
     {2}set show_status true|false{1} - show status messages and progress
     {2}set show_video true|false{1} - show video output (audio only if false)

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -188,7 +188,6 @@ def helptext():
     {2}set player <player app>{1} - use <player app> for playback
     {2}set playerargs <args>{1} - use specified arguments with player
     {2}set search_music true|false{1} - search only music (all categories if false)
-    {2}set yt_dl_cmdline <Python dict format>{1} - initial arguments pased to youtube-dl
     {2}set yt_dl_cmdline <youtube-dl cmdline or Python dict format>{1} - initial arguments
         pased to youtube-dl
     {2}set show_mplayer_keys true|false{1} - show keyboard help for mplayer and mpv

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -231,6 +231,7 @@ def init():
 
     else:
         import_config()
+        init_globals_from_cfg()
 
     init_readline()
     cache.init()
@@ -393,6 +394,14 @@ def init_readline():
         if os.path.exists(g.READLINE_FILE):
             readline.read_history_file(g.READLINE_FILE)
             dbg(c.g + "Read history file" + c.w)
+
+
+def init_globals_from_cfg():
+    """ globals stored in g module are updated with values stored in Config """
+    # currently just ydl_opts require such update.
+    if not g.global_opts_were_already_updated_from_cfg:
+        g.ydl_opts.update(Config.YT_DL_CMDLINE.get.values)
+        g.global_opts_were_already_updated_from_cfg = True
 
 
 def showconfig(_):
@@ -3256,7 +3265,7 @@ def dl_url(url):
 def yt_url(url, print_title=0):
     """ Acess a video by url. """
     try:
-        p = pafy.new(url)
+        p = pafy.new(url, ydl_opts=g.ydl_opts)
 
     except (IOError, ValueError) as e:
         g.message = c.r + str(e) + c.w

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -186,13 +186,13 @@ def get_pafy(item, force=False, callback=None):
     else:
 
         try:
-            p = pafy.new(item.ytid, callback=callback_fn)
+            p = pafy.new(item.ytid, callback=callback_fn, ydl_opts=g.ydl_opts)
 
         except IOError as e:
 
             if "pafy" in str(e):
                 dbg(c.p + "retrying failed pafy get: " + item.ytid + c.w)
-                p = pafy.new(item.ytid, callback=callback)
+                p = pafy.new(item.ytid, callback=callback, ydl_opts=g.ydl_opts)
 
             else:
                 raise


### PR DESCRIPTION
MPS had been changed minimally, by adding 2 checking functions to Config, both modify global dictionary ydl_opts in 'g' module. Also pafy.new() call was updated. 
This patch requires that pafy accepts 'ydl_opts' as argument to 'new' function, in case mps-yt was updated and pafy was not - current design in pafy would cause it to break (TypeError, pafy.new() got unexpected keyword argument ydl_opts)