### PR TITLE
History fix issue 360

### DIFF
--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -68,9 +68,6 @@ class ConfigItem(object):
 
         # handle known player not set
 
-        # sadly, allowed_values is faulty - assumes copy() is always
-        # accessible, causing exception on any string not among allowed_values
-
         if self.allowed_values and value not in self.allowed_values:
             fail_msg = "%s must be one of * - not %s"
             allowed_values = copy.copy(self.allowed_values)

--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -68,6 +68,9 @@ class ConfigItem(object):
 
         # handle known player not set
 
+        # sadly, allowed_values is faulty - assumes copy() is always
+        # accessible, causing exception on any string not among allowed_values
+
         if self.allowed_values and value not in self.allowed_values:
             fail_msg = "%s must be one of * - not %s"
             allowed_values = copy.copy(self.allowed_values)
@@ -289,6 +292,8 @@ class _Config(object):
             ConfigItem("playerargs", ""),
             ConfigItem("encoder", 0, minval=0, check_fn=check_encoder),
             ConfigItem("notifier", ""),
+            ConfigItem("save_history", "all",
+                allowed_values=["", "None", "none", "all", "searches_only"]),
             ConfigItem("checkupdate", True),
             ConfigItem("show_mplayer_keys", True, require_known_player=True),
             ConfigItem("fullscreen", False, require_known_player=True),

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -188,6 +188,8 @@ def helptext():
     {2}set player <player app>{1} - use <player app> for playback
     {2}set playerargs <args>{1} - use specified arguments with player
     {2}set search_music true|false{1} - search only music (all categories if false)
+    {2}set save_history <all|<nothing>|None|searches_only>{1} - optionally save all
+        of entered commands (default), nothing, or just items that were searched for
     {2}set show_mplayer_keys true|false{1} - show keyboard help for mplayer and mpv
     {2}set show_status true|false{1} - show status messages and progress
     {2}set show_video true|false{1} - show video output (audio only if false)

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -391,8 +391,6 @@ def init_readline():
     if has_readline:
         g.READLINE_FILE = os.path.join(get_config_dir(), "input_history")
         if os.path.exists(g.READLINE_FILE):
-            # it appears that Config.ITEM.get does not get CURRENTLY
-            # set value, it gets default item value instead
             history_setting = Config.SAVE_HISTORY.get
             if not history_setting or (history_setting.lower() == "none"):
                 has_readline = False
@@ -403,11 +401,10 @@ def init_readline():
                 readline.read_history_file(g.READLINE_FILE)
                 # readline.remove_history_item(index) is not safe during iter
                 new_history = []
-                for line_no in range(1, readline.get_history_length()):
+                for line_no in range(0, readline.get_history_length()):
                     it = readline.get_history_item(line_no)
                     if it and it.startswith("/"):
                         new_history.append(it)
-                # and also prevents writing to it's file while it's open, so:
                 readline.clear_history()
                 [ readline.add_history(it) for it in new_history ]
                 # optionally, could parse file before read_history_file, but

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -411,9 +411,9 @@ def init_readline():
                 # it would require detecting encoding, line ending type etc.
                 # speed increase could be noticable in case of huge history
             else:
-                msg_1 = "Unreachable, should never happen - unless %s"
-                msg_2 = " had been tampered with. Assuming no history."
-                dbg("%s %s %s" %(msg_1, "Config.SAVE_HISTORY", msg_2))
+                dbg("Unreachable, should never happen - unless"
+                    "Config.SAVE_HISTORY had been tampered with."
+                    "Assuming no history.")
                 has_readline = False
 
 

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -387,12 +387,37 @@ def init_readline():
     if g.command_line:
         return
 
+    global has_readline
     if has_readline:
         g.READLINE_FILE = os.path.join(get_config_dir(), "input_history")
-
         if os.path.exists(g.READLINE_FILE):
-            readline.read_history_file(g.READLINE_FILE)
-            dbg(c.g + "Read history file" + c.w)
+            # it appears that Config.ITEM.get does not get CURRENTLY
+            # set value, it gets default item value instead
+            history_setting = Config.SAVE_HISTORY.get
+            if not history_setting or (history_setting.lower() == "none"):
+                has_readline = False
+            elif history_setting == "all":
+                readline.read_history_file(g.READLINE_FILE)
+                dbg(c.g + "Read history file" + c.w)
+            elif history_setting == "searches_only":
+                readline.read_history_file(g.READLINE_FILE)
+                # readline.remove_history_item(index) is not safe during iter
+                new_history = []
+                for line_no in range(1, readline.get_history_length()):
+                    it = readline.get_history_item(line_no)
+                    if it and it.startswith("/"):
+                        new_history.append(it)
+                # and also prevents writing to it's file while it's open, so:
+                readline.clear_history()
+                [ readline.add_history(it) for it in new_history ]
+                # optionally, could parse file before read_history_file, but
+                # it would require detecting encoding, line ending type etc.
+                # speed increase could be noticable in case of huge history
+            else:
+                msg_1 = "Unreachable, should never happen - unless %s"
+                msg_2 = " had been tampered with. Assuming no history."
+                dbg("%s %s %s"(msg_1, "Config.SAVE_HISTORY", msg_2))
+                has_readline = False
 
 
 def showconfig(_):

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -406,14 +406,14 @@ def init_readline():
                     if it and it.startswith("/"):
                         new_history.append(it)
                 readline.clear_history()
-                [ readline.add_history(it) for it in new_history ]
+                _ = [ readline.add_history(itm) for itm in new_history ]
                 # optionally, could parse file before read_history_file, but
                 # it would require detecting encoding, line ending type etc.
                 # speed increase could be noticable in case of huge history
             else:
                 msg_1 = "Unreachable, should never happen - unless %s"
                 msg_2 = " had been tampered with. Assuming no history."
-                dbg("%s %s %s"(msg_1, "Config.SAVE_HISTORY", msg_2))
+                dbg("%s %s %s" %(msg_1, "Config.SAVE_HISTORY", msg_2))
                 has_readline = False
 
 


### PR DESCRIPTION
This patch checks, during mpsyt startup, in init_readline() function if user wants different history behavior. Config.`save_history` can be set to "all" (current and previous version default behavior), none, or <nothing>, which disables readline, and "searches_only" to filter readline file during each mpsyt startup, leaving only items that were searched for, as described in feature request #360 