### PR TITLE
Fix local variable 'mpv' & 'mplayer' referenced before assignment

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -215,6 +215,10 @@ def process_cl_args():
 def init():
     """ Initial setup. """
 
+    # set player to mpv or mplayer if found, otherwise unset
+    suffix = ".exe" if mswin else ""
+    mplayer, mpv = "mplayer" + suffix, "mpv" + suffix
+
     if not os.path.exists(g.CFFILE):
 
         if has_exefile(mpv):
@@ -231,10 +235,6 @@ def init():
     init_readline()
     cache.init()
     init_transcode()
-
-    # set player to mpv or mplayer if found, otherwise unset
-    suffix = ".exe" if mswin else ""
-    mplayer, mpv = "mplayer" + suffix, "mpv" + suffix
 
     # ensure encoder is not set beyond range of available presets
     if Config.ENCODER.get >= len(g.encoders):


### PR DESCRIPTION
If you don't have `$HOME/config/mps-youtube/config`, you will encounter this error (branch `developer`) : 
```
Traceback (most recent call last):
  File "./mpsyt", line 2, in <module>
    import mps_youtube
  File "/home/dv/py/dev/mps-youtube/mps_youtube/__init__.py", line 2, in <module>
    init()
  File "/home/dv/py/dev/mps-youtube/mps_youtube/main.py", line 220, in init
    if has_exefile(mpv):
UnboundLocalError: local variable 'mpv' referenced before assignment
```