### PR TITLE
Fix right-aligned status line prompt when using colors.

### DIFF
--- a/mps_youtube/c.py
+++ b/mps_youtube/c.py
@@ -34,13 +34,13 @@ else:
 
 r, g, y, b, p, w = red, green, yellow, blue, pink, white
 
-rmcex = re.compile(r'\x1b\[\d*m', re.UNICODE)
+ansirx = re.compile(r'\x1b\[\d*m', re.UNICODE)
 
 def c(colour, text):
     """ Return coloured text. """
     colours = {'r': r, 'g': g, 'y': y, 'b':b, 'p':p}
     return colours[colour] + text + w
 
-def mlen(s):
-    """ Return length of string with color tags removed. """
-    return len(rmcex.sub('', s))
+def charcount(s):
+    """ Return number of characters in string, with ANSI color codes excluded. """
+    return len(ansirx.sub('', s))

--- a/mps_youtube/c.py
+++ b/mps_youtube/c.py
@@ -1,6 +1,7 @@
 """ Module for holding colour code values. """
 
 import os
+import re
 import sys
 
 try:
@@ -33,7 +34,13 @@ else:
 
 r, g, y, b, p, w = red, green, yellow, blue, pink, white
 
+rmcex = re.compile(r'\x1b\[\d*m', re.UNICODE)
+
 def c(colour, text):
     """ Return coloured text. """
     colours = {'r': r, 'g': g, 'y': y, 'b':b, 'p':p}
     return colours[colour] + text + w
+
+def mlen(s):
+    """ Return length of string with color tags removed. """
+    return len(rmcex.sub('', s))

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -793,9 +793,9 @@ def screen_update(fill_blank=True):
         xprint(g.content)
 
     if g.message or g.rprompt:
-        len = c.charcount
+        length = c.charcount
         out = g.message or ''
-        blanks = getxy().width - len(out) - len(g.rprompt or '') - 3
+        blanks = getxy().width - length(out) - length(g.rprompt or '') - 3
         out += ' ' * blanks + (g.rprompt or '')
         xprint(out)
 

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -793,8 +793,9 @@ def screen_update(fill_blank=True):
         xprint(g.content)
 
     if g.message or g.rprompt:
+        len = c.charcount
         out = g.message or ''
-        blanks = getxy().width - c.mlen(out) - c.mlen(g.rprompt or '') - 3
+        blanks = getxy().width - len(out) - len(g.rprompt or '') - 3
         out += ' ' * blanks + (g.rprompt or '')
         xprint(out)
 

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -794,7 +794,7 @@ def screen_update(fill_blank=True):
 
     if g.message or g.rprompt:
         out = g.message or ''
-        blanks = getxy().width - len(out) - len(g.rprompt or '')
+        blanks = getxy().width - c.mlen(out) - c.mlen(g.rprompt or '') - 3
         out += ' ' * blanks + (g.rprompt or '')
         xprint(out)
 


### PR DESCRIPTION
Apply regex to calculate actual status line length regardless of color codes.