### PR TITLE
remove unneeded showconfig() argument

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -437,7 +437,7 @@ def setconfig(key, val):
         # Config.save() will be called by Config.set() method
         message = Config[key.upper()].set(val)
 
-    showconfig(1)
+    showconfig()
     g.message = message
 
 


### PR DESCRIPTION
Not sure what the intention behind this was but keeping it as it is crashes mps-youtube.