### PR TITLE
Add settings for default audio format

### DIFF
--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -302,6 +302,8 @@ class _Config(object):
             ConfigItem("window_size", "",
                 check_fn=check_win_size, require_known_player=True),
             ConfigItem("download_command", ''),
+            ConfigItem("audio_format", "auto",
+                allowed_values="auto webm m4a".split()),
             ConfigItem("api_key", "AIzaSyCIM4EzNqi1in22f4Z3Ru3iYvLaY8tc3bo",
                 check_fn=check_api_key)
             ] 

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -198,6 +198,7 @@ def helptext():
     {2}set show_video true|false{1} - show video output (audio only if false)
     {2}set window_pos <top|bottom>-<left|right>{1} - set player window position
     {2}set window_size <number>x<number>{1} - set player window width & height
+    {2}set audio_format <auto|m4a|webm>{1} - set default music audio format
     {2}set api_key <key>{1} - use a different API key for accessing the YouTube Data API
     """.format(c.ul, c.w, c.y, '\n{0}set max_results <number>{1} - show <number> re'
                'sults when searching (max 50)'.format(c.y, c.w) if not

--- a/mps_youtube/streams.py
+++ b/mps_youtube/streams.py
@@ -94,6 +94,13 @@ def select(slist, q=0, audio=False, m4a_ok=True, maxres=None):
         streams = [x for x in slist if x['mtype'] == "audio"]
         if not m4a_ok:
             streams = [x for x in streams if not x['ext'] == "m4a"]
+        if not Config.AUDIO_FORMAT.get == "auto":
+            if m4a_ok and Config.AUDIO_FORMAT.get == "m4a":
+                streams = [x for x in streams if x['ext'] == "m4a"]
+            if Config.AUDIO_FORMAT.get == "webm":
+                streams = [x for x in streams if x['ext'] == "webm"]
+            if not streams:
+                streams = [x for x in slist if x['mtype'] == "audio"]
         streams = sorted(streams, key=getbitrate, reverse=True)
     else:
         streams = [x for x in slist if x['mtype'] == "normal" and okres(x)]


### PR DESCRIPTION
Referencing issue  #466 

I have added `m4a` and `webm` as options for `audio_format` configuration
