### PR TITLE
Add a reverse command

### DIFF
--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -63,6 +63,7 @@ def helptext():
     {2}mix <number>{1} - show YouTube mix playlist from item in results.
 
     {2}shuffle{1} - Shuffle the displayed results.
+    {2}reverse{1} or {2}reverse <number>-<number>{1} - Reverse the displayed results or item range.
     """.format(c.ul, c.w, c.y)),
 
         ("download", "Downloading and Playback", """

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -63,7 +63,8 @@ def helptext():
     {2}mix <number>{1} - show YouTube mix playlist from item in results.
 
     {2}shuffle{1} - Shuffle the displayed results.
-    {2}reverse{1} or {2}reverse <number>-<number>{1} - Reverse the displayed results or item range.
+    {2}reverse{1} or {2}reverse <number>-<number>{1} - Reverse the displayed items or item range.
+    {2}reverse all{1} - Reverse order of entire loaded playlist
     """.format(c.ul, c.w, c.y)),
 
         ("download", "Downloading and Playback", """

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2641,6 +2641,12 @@ def reverse_songs_range(lower, upper):
 @commands.command(r'reverse all')
 def reverse_playlist():
     """ Reverse order of entire loaded playlist. """
+    # Prevent crash if no last query
+    if g.last_search_query == (None, None):
+        g.content = logo()
+        g.message = "No playlist loaded"
+        return
+
     songs_list_or_func = g.last_search_query[1]['func']
     if callable(songs_list_or_func):
         songs = reversed(songs_list_or_func(0,None))

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2643,7 +2643,7 @@ def reverse_playlist():
     """ Reverse order of entire loaded playlist. """
     songs_list_or_func = g.last_search_query[1]['func']
     if callable(songs_list_or_func):
-        songs = reversed(songs_list_or_func(0,1000))
+        songs = reversed(songs_list_or_func(0,None))
     else:
         songs = reversed(songs_list_or_func)
 

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2619,6 +2619,14 @@ def shuffle_fn():
     g.content = generate_songlist_display()
 
 
+@commands.command(r'reverse')
+def reverse_fn():
+    """ Reverse order of displayed items. """
+    g.model.songs = g.model.songs[::-1]
+    g.message = c.y + "Items reversed" + c.w
+    g.content = generate_songlist_display()
+
+
 @commands.command(r'clearcache')
 def clearcache():
     """ Clear cached items - for debugging use. """

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2664,8 +2664,6 @@ def reverse_playlist():
         g.message = c.r + "A problem occured reversing all. " 
         g.message += "Use " + c.y + "reverse" + c.r + " instead." + c.w
         g.content = generate_songlist_display()
-        return
-
 
 
 @commands.command(r'clearcache')

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2623,7 +2623,7 @@ def shuffle_fn():
 def reverse_songs():
     """ Reverse order of displayed items. """
     g.model.songs = g.model.songs[::-1]
-    g.message = c.y + "Items reversed" + c.w
+    g.message = c.y + "Reversed displayed songs" + c.w
     g.content = generate_songlist_display()
 
 
@@ -2642,18 +2642,30 @@ def reverse_songs_range(lower, upper):
 def reverse_playlist():
     """ Reverse order of entire loaded playlist. """
     # Prevent crash if no last query
-    if g.last_search_query == (None, None):
+    if g.last_search_query == (None, None) or \
+            'func' not in g.last_search_query[1]:
         g.content = logo()
         g.message = "No playlist loaded"
         return
 
-    songs_list_or_func = g.last_search_query[1]['func']
-    if callable(songs_list_or_func):
-        songs = reversed(songs_list_or_func(0,None))
-    else:
-        songs = reversed(songs_list_or_func)
+    try:
+        songs_list_or_func = g.last_search_query[1]['func']
+        if callable(songs_list_or_func):
+            songs = reversed(songs_list_or_func(0,None))
+        else:
+            songs = reversed(songs_list_or_func)
 
-    paginatesongs(list(songs))
+        paginatesongs(list(songs))
+        g.message = c.y + "Reversed entire playlist" + c.w
+        g.content = generate_songlist_display()
+        
+    except TypeError:
+        #TODO Error occurs reversing certain playlists (eg. YT user songs). 
+        g.message = c.r + "A problem occured reversing all. " 
+        g.message += "Use " + c.y + "reverse" + c.r + " instead." + c.w
+        g.content = generate_songlist_display()
+        return
+
 
 
 @commands.command(r'clearcache')

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -1477,7 +1477,7 @@ def view_history():
     history = g.userhist.get('history')
     #g.last_opened = ""
     try:
-        paginatesongs(list(history.songs))
+        paginatesongs(list(reversed(history.songs)))
         g.message = "Viewing play history"
 
     except AttributeError:

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2638,6 +2638,18 @@ def reverse_songs_range(lower, upper):
     g.content = generate_songlist_display()
     
 
+@commands.command(r'reverse all')
+def reverse_playlist():
+    """ Reverse order of entire loaded playlist. """
+    songs_list_or_func = g.last_search_query[1]['func']
+    if callable(songs_list_or_func):
+        songs = reversed(songs_list_or_func(0,1000))
+    else:
+        songs = reversed(songs_list_or_func)
+
+    paginatesongs(list(songs))
+
+
 @commands.command(r'clearcache')
 def clearcache():
     """ Clear cached items - for debugging use. """

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2620,12 +2620,23 @@ def shuffle_fn():
 
 
 @commands.command(r'reverse')
-def reverse_fn():
+def reverse_songs():
     """ Reverse order of displayed items. """
     g.model.songs = g.model.songs[::-1]
     g.message = c.y + "Items reversed" + c.w
     g.content = generate_songlist_display()
 
+
+@commands.command(r'reverse\s*(\d{1,4})\s*-\s*(\d{1,4})\s*')
+def reverse_songs_range(lower, upper):
+    """ Reverse the songs within a specified range. """
+    lower, upper = int(lower), int(upper)
+    if lower > upper: lower, upper = upper, lower
+    
+    g.model.songs[lower-1:upper] = reversed(g.model.songs[lower-1:upper])
+    g.message = c.y + "Reversed range: " + str(lower) + "-" + str(upper) + c.w
+    g.content = generate_songlist_display()
+    
 
 @commands.command(r'clearcache')
 def clearcache():


### PR DESCRIPTION
Referencing issue #442.

This implements the `reverse`, `reverse <number>-<number>`, and `reverse all` commands for editing playlists. `reverse all` is especially useful for #472 since it moves the latest played songs to the start of history.