### PR TITLE
Make changing window title a configurable option

### DIFF
--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -305,7 +305,8 @@ class _Config(object):
             ConfigItem("audio_format", "auto",
                 allowed_values="auto webm m4a".split()),
             ConfigItem("api_key", "AIzaSyCIM4EzNqi1in22f4Z3Ru3iYvLaY8tc3bo",
-                check_fn=check_api_key)
+                check_fn=check_api_key),
+            ConfigItem("set_title", True)
             ] 
 
     def __getitem__(self, key):

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -210,6 +210,7 @@ def helptext():
     {2}set window_size <number>x<number>{1} - set player window width & height
     {2}set audio_format <auto|m4a|webm>{1} - set default music audio format
     {2}set api_key <key>{1} - use a different API key for accessing the YouTube Data API
+    {2}set set_title true|false{1} - change window title
     """.format(c.ul, c.w, c.y, '\n{0}set max_results <number>{1} - show <number> re'
                'sults when searching (max 50)'.format(c.y, c.w) if not
                g.detectable_size else '')),

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -29,6 +29,7 @@ import pafy
 
 from . import g, c, commands, screen, history, util
 from . import __version__, playlists, content
+from . import config
 
 try:
     import readline
@@ -105,7 +106,8 @@ def prompt_for_exit():
 
 def main():
     """ Main control loop. """
-    util.set_window_title("mpsyt")
+    if config.SET_TITLE.get:
+        util.set_window_title("mpsyt")
 
     if not g.command_line:
         g.content = content.logo(col=c.g, version=__version__) + "\n\n"

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -36,7 +36,8 @@ def play_range(songlist, shuffle=False, repeat=False, override=False):
         if hasnext:
             streams.preload(songlist[n + 1], override=override)
 
-        util.set_window_title(song.title + " - mpsyt")
+        if config.SET_TITLE.get:
+            util.set_window_title(song.title + " - mpsyt")
         try:
             returncode = _playsong(song, override=override)
 
@@ -46,7 +47,8 @@ def play_range(songlist, shuffle=False, repeat=False, override=False):
             screen.reset_terminal()
             g.message = c.y + "Playback halted" + c.w
             break
-        util.set_window_title("mpsyt")
+        if config.SET_TITLE.get:
+            util.set_window_title("mpsyt")
 
         if returncode == 42:
             n -= 1


### PR DESCRIPTION
I have plenty of these in my ~/.fluxbox/keys:

`Mod4 x         :exec wmctrl -a uxterm || uxterm`
`Mod4 e      :exec wmctrl -a emacs@ || emacs`
`(...)`

When I press Mod4-x fluxbox moves focus to an existing window titled
`uxterm' or it starts a new instance of uxterm if such window does not
exist.  When mpsyt changes its window title automatically it breaks
this workflow.  I have added a new config option called set_title
which enables/disables automatic changing of window title.  It is set
to True by default for backward compatibility.
