### PR TITLE
Added command --no-textart to disable textart, so users with screen reader wouldn't get confused by it

### DIFF
--- a/mps_youtube/content.py
+++ b/mps_youtube/content.py
@@ -211,7 +211,7 @@ def logo(col=None, version=""):
     indent, newlines = (0 if x < 0 else x for x in (indent, newlines))
     lines = [" " * indent + l for l in lines]
     logo_txt = "\n".join(lines) + "\n" * newlines
-    return "" if g.debug_mode else logo_txt
+    return "" if g.debug_mode or g.no_textart else logo_txt
 
 
 def playlists_display():

--- a/mps_youtube/g.py
+++ b/mps_youtube/g.py
@@ -27,6 +27,7 @@ browse_mode = "normal"
 preloading = []
 # expiry = 5 * 60 * 60  # 5 hours
 no_clear_screen = False
+no_textart = False
 max_retries = 3
 max_cached_streams = 1500
 username_query_cache = collections.OrderedDict()

--- a/mps_youtube/init.py
+++ b/mps_youtube/init.py
@@ -217,6 +217,7 @@ def _process_cl_args():
     parser.add_argument('--logging', '-l', action='store_true')
     parser.add_argument('--no-autosize', action='store_true')
     parser.add_argument('--no-preload', action='store_true')
+    parser.add_argument('--no-textart', action='store_true')
     args = parser.parse_args()
 
     if args.version:
@@ -244,6 +245,9 @@ def _process_cl_args():
 
     if args.no_preload:
         g.preload_disabled = True
+
+    if args.no_textart:
+        g.no_textart = True
 
     g.argument_commands = args.commands
 


### PR DESCRIPTION
Person at https://github.com/mps-youtube/mps-youtube/issues/515 asked for command to disable textart at start of mpsyt.