### PR TITLE
Handle mpv sending bad `time-pos` data

### DIFF
--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -489,7 +489,8 @@ def _player_status(po_obj, prefix, songlength=0, mpv=False, sockpath=None):
                     observe_full = True
 
                 if resp.get('event') == 'property-change' and resp['id'] == 1:
-                    elapsed_s = int(resp['data'])
+                    if resp['data'] is not None:
+                        elapsed_s = int(resp['data'])
 
                 elif resp.get('event') == 'property-change' and resp['id'] == 2:
                     volume_level = int(resp['data'])


### PR DESCRIPTION
mpv sometimes sends `{"event":"property-change","id":1,"name":"time-pos","data":null}` on the socket; for example when the user has configured mpv (say, via `mpv.conf`) to loop over, then mpv sends this malformed event upon a new iteration of playback

Steps to reproduce:
1. Use mpv ~ 0.18.1
2. Configure mpv to play on loop, by adding the line `loop=inf` to `~/.config/mpv/mpv.conf`
3. Play something in mps-youtube with the player set to mpv and wait till it ends

Expected Behaviour:
- mpv restarts playing after playback ends
- mps-youtube handles mpv looping gracefully

Actual Behaviour:
- mpv tries to restart playing
- mps-youtube crashes with:
```
Traceback (most recent call last):
  File "/usr/bin/mpsyt", line 9, in <module>
    load_entry_point('mps-youtube==0.2.7.1', 'console_scripts', 'mpsyt')()
  File "/usr/lib/python3.5/site-packages/mps_youtube/main.py", line 141, in main
    if matchfunction(i.function, i.regex, userinput):
  File "/usr/lib/python3.5/site-packages/mps_youtube/main.py", line 64, in matchfunction
    func(*matches)
  File "/usr/lib/python3.5/site-packages/mps_youtube/commands/play.py", line 85, in play
    play_range(songlist, shuffle, repeat, override)
  File "/usr/lib/python3.5/site-packages/mps_youtube/player.py", line 41, in play_range
    returncode = _playsong(song, override=override)
  File "/usr/lib/python3.5/site-packages/mps_youtube/player.py", line 215, in _playsong
    returncode = _launch_player(song, songdata, cmd)
  File "/usr/lib/python3.5/site-packages/mps_youtube/player.py", line 417, in _launch_player
    sockpath=sockpath)
  File "/usr/lib/python3.5/site-packages/mps_youtube/player.py", line 493, in _player_status
    elapsed_s = int(resp['data'])
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```