### PR TITLE
Add mpv as a recommended player in mac installation section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,10 @@ Installing youtube_dl is highly recommended::
 
 Additional Mac OS X installation notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    
+Install mpv (recommended player) with `Homebrew <http://brew.sh>`_::
+
+    brew install mpv
+
 Install mplayer with `MacPorts <http://www.macports.org>`_::
 
     sudo port install MPlayer


### PR DESCRIPTION
Since mplayer is having issues playing certain tracks as mentioned in [Issue 518](https://github.com/mps-youtube/mps-youtube/issues/518), the README should be updated with mpv installation instructions for Mac OSX. 

I know I had issues when I installed mplayer first and got confused :P