### PR TITLE
Allow exit code 3 as non-failed exit code

### DIFF
--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -213,7 +213,7 @@ def _playsong(song, failcount=0, override=False):
 
     cmd = _generate_real_playerargs(song, override, stream, video)
     returncode = _launch_player(song, songdata, cmd)
-    failed = returncode not in (0, 42, 43)
+    failed = returncode not in (0, 3, 42, 43)
 
     if failed and failcount < g.max_retries:
         util.dbg(c.r + "stream failed to open" + c.w)


### PR DESCRIPTION
mpv now on default uses exit code 3 when exiting when done