### PR TITLE
Fix syntax error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ options = dict(
     author="np1",
     author_email="np1nagev@gmail.com",
     url="https://github.com/mps-youtube/mps-youtube",
-    download_url="https://github.com/mps-youtube/mps-youtube/archive/v%s.tar.gz" % VERSION
+    download_url="https://github.com/mps-youtube/mps-youtube/archive/v%s.tar.gz" % VERSION,
     packages=['mps_youtube', 'mps_youtube.commands'],
     entry_points={'console_scripts': ['mpsyt = mps_youtube:main.main']},
     install_requires=['pafy >= 0.3.82, != 0.4.0, != 0.4.1, != 0.4.2'],


### PR DESCRIPTION
Fixes the following syntax error when building mps-youtube by adding a missing comma.
```
$ python3 setup.py build
  File "setup.py", line 29
    packages=['mps_youtube', 'mps_youtube.commands'],
           ^
SyntaxError: invalid syntax
```
This started in PR https://github.com/mps-youtube/mps-youtube/pull/585, please review this to make sure its right. I don't know python well and only know that it works for me.