### PR TITLE
Fix misuse of flags in re.sub() call

### DIFF
--- a/mps_youtube/commands/local_playlist.py
+++ b/mps_youtube/commands/local_playlist.py
@@ -102,7 +102,7 @@ def save_last():
         # save using artist name in postion 1
         if g.model:
             saveas = g.model[0].title[:18].strip()
-            saveas = re.sub(r"[^-\w]", "-", saveas, re.UNICODE)
+            saveas = re.sub(r"[^-\w]", "-", saveas, flags=re.UNICODE)
 
         # loop to find next available name
         post = 0


### PR DESCRIPTION
The 4th argument of `re.sub()` is maximum number of substitutions, not flags.

Found using [pydiatra](https://github.com/jwilk/pydiatra).