### PR TITLE
Feature request: allow user to list yt video ID in search and playlist results. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ parts
 bin
 var
 tags
+.env

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+Version 0.2.7.1
+6 July 2016
+
+Bug fixes:
+----------
+- Fix pickle error (@ids1024) (#503)
+- Install LICENSE, README.md, and CHANGELOG as package_data (@ids1024)
+- Update youtube-dl in py2exe build (@ids1024)
+
+-------------------------------------------------------------------------------
+
 Version 0.2.7
 27 June 2016
 

--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,7 @@ Run via Docker container
 
 Using `Docker <http://www.docker.com>`_, run with::
 
-    sudo docker run -v /dev/snd:/dev/snd -it --rm --privileged --name mpsyt rothgar/mpsyt
+    sudo docker run --device /dev/snd -it --rm --name mpsyt rothgar/mpsyt
 
 Additional Docker notes
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Install mpv (recommended player) with `Homebrew <http://brew.sh>`_::
 
     brew install mpv
 
-Install mplayer with `MacPorts <http://www.macports.org>`_::
+Alternately, you can install mplayer with `MacPorts <http://www.macports.org>`_::
 
     sudo port install MPlayer
 
@@ -120,11 +120,15 @@ Install the python `colorama <https://pypi.python.org/pypi/colorama>`_ module to
 
     pip3 install colorama
 
-Download mplayer for your CPU type from the "Build Selection table" `here <http://oss.netfarm.it/mplayer-win32.php>`_.
+Mpsyt requires a player to use as a backend, with either mpv or mplayer supported. Mpv is the recommended option.
+
+Mpv can be downloaded from https://mpv.srsfckn.biz/
+
+Extract both ``mpv.exe`` and ``mpv.com`` to the same folder as ``mpsyt.exe`` or to a folder in the system path.
+
+Alternately, mplayer can be downloaded from http://oss.netfarm.it/mplayer
 
 Extract the ``mplayer.exe`` file, saving it to the folder that ``mpsyt.exe`` resides in (usually ``C:\PythonXX\Scripts\``) or to a folder in the system path.
-
-Alternatively to mplayer, use ``mpv.exe`` which can be downloaded from: http://mpv.io/installation/
 
 Run via Docker container
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Features
 - Convert to mp3 & other formats (requires ffmpeg or avconv)
 - View video comments
 - Works with Python 3.x
-- Works with Windows, Linux and Mac OS X 
+- Works with Windows, Linux and Mac OS X
 - Requires mplayer or mpv
 
 This project is based on `mps <https://github.com/np1/mps>`_, a terminal based program to search, stream and download music.  This implementation uses YouTube as a source of content and can play and download video as well as audio.  The `pafy <https://github.com/np1/pafy>`_ library handles interfacing with YouTube.
@@ -68,7 +68,7 @@ Music Album Matching
 
 .. image:: http://np1.github.io/mpsyt-images2/album-2.png
 
-An album title can be specified and mps-youtube will attempt to find matches for each track of the album, based on title and duration.  Type ``help search`` for more info.  
+An album title can be specified and mps-youtube will attempt to find matches for each track of the album, based on title and duration.  Type ``help search`` for more info.
 
 Customisation
 ~~~~~~~~~~~~~
@@ -90,7 +90,7 @@ Installation
 ------------
 
 Using `pip <http://www.pip-installer.org>`_::
-    
+
     [sudo] pip3 install mps-youtube
 
 Installing youtube_dl is highly recommended::
@@ -141,7 +141,7 @@ Run via Docker container
 
 Using `Docker <http://www.docker.com>`_, run with::
 
-    sudo docker run -v /dev/snd:/dev/snd -it --rm --privileged --name mpsyt mpsyt
+    sudo docker run -v /dev/snd:/dev/snd -it --rm --privileged --name mpsyt rothgar/mpsyt
 
 Additional Docker notes
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -174,9 +174,9 @@ Usage
 -----
 
 mps-youtube is run on the command line using the command::
-    
+
     mpsyt
-    
+
 Enter ``h`` from within the program for help.
 
 IRC

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ Additional Linux installation notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 For mpris2 support, install the python bindings for dbus and gobject::
 
-    [sudo] pip3 install dbus pygobject
+    [sudo] pip3 install dbus-python pygobject
 
 Additional Mac OS X installation notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,12 @@ Installing youtube_dl is highly recommended::
 
     [sudo] pip3 install youtube_dl
 
+Additional Linux installation notes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For mpris2 support, install the python bindings for dbus and gobject::
+
+    [sudo] pip3 install dbus pygobject
+
 Additional Mac OS X installation notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Install mpv (recommended player) with `Homebrew <http://brew.sh>`_::

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 # This file is used by clients to check for updates
 
-version 0.2.7
+version 0.2.7.1
 

--- a/mps_youtube/__init__.py
+++ b/mps_youtube/__init__.py
@@ -1,5 +1,5 @@
-__version__ = "0.2.7"
-__notes__ = "released 27 June 2016"
+__version__ = "0.2.7.1"
+__notes__ = "released 6 July 2016"
 __author__ = "np1"
 __license__ = "GPLv3"
 __url__ = "http://github.com/np1/mps-youtube"

--- a/mps_youtube/commands/__init__.py
+++ b/mps_youtube/commands/__init__.py
@@ -9,7 +9,7 @@ Command = collections.namedtuple('Command', 'regex category usage function')
 # input types
 WORD = r'[^\W\d][-\w\s]{,100}'
 RS = r'(?:(?:repeat|shuffle|-[avfw])\s*)'
-PL = r'\S*?((?:RD|PL)[-_0-9a-zA-Z]+)\s*'
+PL = r'\S*?((?:RD|PL|LL)[-_0-9a-zA-Z]+)\s*'
 
 
 def command(regex):

--- a/mps_youtube/commands/download.py
+++ b/mps_youtube/commands/download.py
@@ -375,7 +375,9 @@ def _download(song, filename, url=None, audio=False, allow_transcode=True):
         outfh.write(chunk)
         elapsed = time.time() - t0
         bytesdone += len(chunk)
-        rate = (bytesdone / 1024) / elapsed
+        rate = 0
+        if elapsed != 0:
+            rate = (bytesdone / 1024) / elapsed
         if rate:
             eta = (total - bytesdone) / (rate * 1024)
         else:

--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -109,7 +109,7 @@ def fetch_comments(item):
     for n, com in enumerate(coms, 1):
         snippet = com.get('snippet', {})
         poster = snippet.get('authorDisplayName')
-        _, shortdate = util.yt_datetime(snippet.get('publishedAt', ''))
+        shortdate = util.yt_datetime(snippet.get('publishedAt', ''))[1]
         text = snippet.get('textDisplay', '')
         cid = ("%s/%s" % (n, len(coms)))
         commentstext += ("%s %-35s %s\n" % (cid, c.c("g", poster), shortdate))

--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -1,5 +1,5 @@
 import re
-import time
+from datetime import datetime
 import socket
 import traceback
 from urllib.request import urlopen
@@ -184,16 +184,15 @@ def info(num):
 
         ytpl_desc = ytpl.description
         g.content = generate_songlist_display()
-
-        created = util.yt_datetime(p['created'])[0]
-        updated = util.yt_datetime(p['updated'])[0]
+        created = util.yt_datetime_local(p['created'])
+        updated = util.yt_datetime_local(p['updated'])
         out = c.ul + "Playlist Info" + c.w + "\n\n"
         out += p['title']
         out += "\n" + ytpl_desc
         out += ("\n\nAuthor     : " + p['author'])
         out += "\nSize       : " + str(p['size']) + " videos"
-        out += "\nCreated    : " + time.strftime("%x %X", created)
-        out += "\nUpdated    : " + time.strftime("%x %X", updated)
+        out += "\nCreated    : " + created[1] + " " + created[2]
+        out += "\nUpdated    : " + updated[1] + " " + updated[2]
         out += "\nID         : " + str(p['link'])
         out += ("\n\n%s[%sPress enter to go back%s]%s" % (c.y, c.w, c.y, c.w))
         g.content = out
@@ -205,13 +204,14 @@ def info(num):
         item = (g.model[int(num) - 1])
         streams.get(item)
         p = util.get_pafy(item)
-        pub = time.strptime(str(p.published), "%Y-%m-%d %H:%M:%S")
+        pub = datetime.strptime(str(p.published), "%Y-%m-%d %H:%M:%S")
+        pub = util.utc2local(pub)
         screen.writestatus("Fetched")
         out = c.ul + "Video Info" + c.w + "\n\n"
         out += p.title or ""
         out += "\n" + (p.description or "")
         out += "\n\nAuthor     : " + str(p.author)
-        out += "\nPublished  : " + time.strftime("%c", pub)
+        out += "\nPublished  : " + pub.strftime("%c")
         out += "\nView count : " + str(p.viewcount)
         out += "\nRating     : " + str(p.rating)[:4]
         out += "\nLikes      : " + str(p.likes)

--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -5,6 +5,12 @@ import base64
 import logging
 from datetime import datetime, timedelta
 
+from argparse import ArgumentParser
+parser = ArgumentParser()
+parser.add_argument('-d', '--duration', choices=('any', 'short', 'medium', 'long'))
+parser.add_argument('-a', '--after')
+parser.add_argument('search', nargs='+')
+
 import pafy
 
 from .. import g, c, screen, config, util, content
@@ -212,19 +218,10 @@ def related_search(vitem):
 @command(r'(?:search|\.|/)\s*([^./].{1,500})')
 def search(term):
     """ Perform search. """
-    videoDuration = 'any'
-    if term.startswith('['):
-        split = term.split(' ')
-        if len(split) > 1 and split[0].endswith(']'):
-            videoDuration = split[0][1:-1]
-            term = ' '.join(split[1:])
-
-    after = None
-    if term.endswith('|'):
-        split = term.split(' ')
-        if len(split) > 1 and split[-1].startswith('|'):
-            after = split[-1][1:-1]
-            term = ' '.join(split[:-1])
+    args = parser.parse_args(term.split(' '))
+    videoDuration = args.duration if args.duration else 'any'
+    after = args.after
+    term = ' '.join(args.search)
 
     if not term or len(term) < 2:
         g.message = c.r + "Not enough input" + c.w

--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -218,12 +218,12 @@ def related_search(vitem):
 @command(r'(?:search|\.|/)\s*([^./].{1,500})')
 def search(term):
     """ Perform search. """
-    try:     #TODO make use of unkowns
+    try:     #TODO make use of unknowns
         args, unknown = parser.parse_known_args(term.split(' '))
         videoDuration = args.duration if args.duration else 'any'
         after = args.after
         term = ' '.join(args.search)
-    except SystemExit as e:  #<------ argsparse calls exit()
+    except SystemExit:  #<------ argsparse calls exit()
         g.message = c.b + "Bad syntax. Enter h for help" + c.w
         return
 

--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -406,6 +406,7 @@ def get_tracks_from_json(jsons):
             #XXX this is a very poor attempt to calculate a rating value
             rating = 5.*likes/(likes+dislikes) if (likes+dislikes) > 0 else 0
             category = snippet.get('categoryId')
+            publisheddatetime = util.yt_datetime(snippet.get('publishedAt', ''))
 
             # cache video information in custom global variable store
             g.meta[ytid] = dict(
@@ -420,7 +421,8 @@ def get_tracks_from_json(jsons):
                 uploaderName=snippet.get('channelTitle'),
                 category=category,
                 aspect="custom", #XXX
-                uploaded=util.yt_datetime(snippet.get('publishedAt', ''))[1],
+                uploaded=publisheddatetime[1],
+                uploadedTime=publisheddatetime[2],
                 likes=str(num_repr(likes)),
                 dislikes=str(num_repr(dislikes)),
                 commentCount=str(num_repr(int(stats.get('commentCount', 0)))),

--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -218,10 +218,14 @@ def related_search(vitem):
 @command(r'(?:search|\.|/)\s*([^./].{1,500})')
 def search(term):
     """ Perform search. """
-    args = parser.parse_args(term.split(' '))
-    videoDuration = args.duration if args.duration else 'any'
-    after = args.after
-    term = ' '.join(args.search)
+    try:     #TODO make use of unkowns
+        args, unknown = parser.parse_known_args(term.split(' '))
+        videoDuration = args.duration if args.duration else 'any'
+        after = args.after
+        term = ' '.join(args.search)
+    except SystemExit as e:  #<------ argsparse calls exit()
+        g.message = c.b + "Bad syntax. Enter h for help" + c.w
+        return
 
     if not term or len(term) < 2:
         g.message = c.r + "Not enough input" + c.w

--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -219,7 +219,7 @@ def related_search(vitem):
 def search(term):
     """ Perform search. """
     try:     #TODO make use of unknowns
-        args, unknown = parser.parse_known_args(term.split(' '))
+        args, unknown = parser.parse_known_args(term.split())
         videoDuration = args.duration if args.duration else 'any'
         after = args.after
         term = ' '.join(args.search)

--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -406,7 +406,7 @@ def get_tracks_from_json(jsons):
             #XXX this is a very poor attempt to calculate a rating value
             rating = 5.*likes/(likes+dislikes) if (likes+dislikes) > 0 else 0
             category = snippet.get('categoryId')
-            publisheddatetime = util.yt_datetime(snippet.get('publishedAt', ''))
+            publishedlocaldatetime = util.yt_datetime_local(snippet.get('publishedAt', ''))
 
             # cache video information in custom global variable store
             g.meta[ytid] = dict(
@@ -421,8 +421,8 @@ def get_tracks_from_json(jsons):
                 uploaderName=snippet.get('channelTitle'),
                 category=category,
                 aspect="custom", #XXX
-                uploaded=publisheddatetime[1],
-                uploadedTime=publisheddatetime[2],
+                uploaded=publishedlocaldatetime[1],
+                uploadedTime=publishedlocaldatetime[2],
                 likes=str(num_repr(likes)),
                 dislikes=str(num_repr(dislikes)),
                 commentCount=str(num_repr(int(stats.get('commentCount', 0)))),

--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -306,7 +306,7 @@ class _Config(object):
                 allowed_values="auto webm m4a".split()),
             ConfigItem("api_key", "AIzaSyCIM4EzNqi1in22f4Z3Ru3iYvLaY8tc3bo",
                 check_fn=check_api_key),
-            ConfigItem("autoplay", True)
+            ConfigItem("autoplay", False)
             ]
 
     def __getitem__(self, key):

--- a/mps_youtube/content.py
+++ b/mps_youtube/content.py
@@ -84,14 +84,14 @@ def generate_songlist_display(song=False, zeromsg=None):
     user_columns = _get_user_columns() if have_meta else []
     maxlength = max(x.length for x in g.model)
     lengthsize = 8 if maxlength > 35999 else 7
-    lengthsize = 5 if maxlength < 6000 else lengthsize
+    lengthsize = 6 if maxlength < 6000 else lengthsize
     reserved = 9 + lengthsize + len(user_columns)
     cw = getxy().width
     cw -= 1
     title_size = cw - sum(1 + x['size'] for x in user_columns) - reserved
     before = [{"name": "idx", "size": 3, "heading": "Num"},
               {"name": "title", "size": title_size, "heading": "Title"}]
-    after = [{"name": "length", "size": lengthsize, "heading": "Time"}]
+    after = [{"name": "length", "size": lengthsize, "heading": "Length"}]
     columns = before + user_columns + after
 
     for n, column in enumerate(columns):
@@ -167,6 +167,7 @@ def _get_user_columns():
                 "rating": dict(name="rating", size=4, heading="Rtng"),
                 "comments": dict(name="commentCount", size=4, heading="Comm"),
                 "date": dict(name="uploaded", size=8, heading="Date"),
+                "time": dict(name="uploadedTime", size=11, heading="Time"),
                 "user": dict(name="uploaderName", size=10, heading="User"),
                 "likes": dict(name="likes", size=4, heading="Like"),
                 "dislikes": dict(name="dislikes", size=4, heading="Dslk"),

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -33,11 +33,9 @@ def helptext():
     {2}set search_music true{1}  - search only YouTube music category.
 
     {2}/<query>{1} or {2}.<query>{1} to search for videos. e.g., {2}/daft punk{1}
-    {2}/[<videoDuration>] <query>{1} or {2}.[<videoDuration>] <query>{1} e.g., {2}/[long] daft punk{1}
-      {2}videoDuration{1} options: any, long, medium, short
-    {2}/<query> |<searchAfter>|{1} to search for videos after a certain time frame. e.g., {2}/daft punk |week|{1}
-      {2}searchAfter{1}: day, week, month, year, yyyy-mm-dd, yyyy-mm-ddThh:mm:ddZ
-        {2}/query |2015-02-23T00:00:00Z|{1} is the same as {2}/query |2015-02-23|{1}
+        [-d {{any,short,medium,long}}] [-a AFTER] search [search ...] {2}/-a short -d day hits{1}
+         AFTER: day, week, month, year, yyyy-mm-dd, yyyy-mm-ddThh:mm:ddZ
+        {2}/ --after 2016-08-11 tweekaz --duration long{1}
     {2}//<query>{1} or {2}..<query>{1} - search for YouTube playlists. e.g., \
     {2}//80's music{1}
     {2}n{1} and {2}p{1} - continue search to next/previous pages.

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -34,7 +34,10 @@ def helptext():
 
     {2}/<query>{1} or {2}.<query>{1} to search for videos. e.g., {2}/daft punk{1}
     {2}/[<videoDuration>] <query>{1} or {2}.[<videoDuration>] <query>{1} e.g., {2}/[long] daft punk{1}
-        videoDuration options: any, long, medium, short
+      {2}videoDuration{1} options: any, long, medium, short
+    {2}/<query> |<searchAfter>|{1} to search for videos after a certain time frame. e.g., {2}/daft punk |week|{1}
+      {2}searchAfter{1}: day, week, month, year, yyyy-mm-dd, yyyy-mm-ddThh:mm:ddZ
+        {2}/query |2015-02-23T00:00:00Z|{1} is the same as {2}/query |2015-02-23|{1}
     {2}//<query>{1} or {2}..<query>{1} - search for YouTube playlists. e.g., \
     {2}//80's music{1}
     {2}n{1} and {2}p{1} - continue search to next/previous pages.

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -193,7 +193,7 @@ def helptext():
     {2}set all default{1} - restore default settings
     {2}set checkupdate true|false{1} - check for updates on exit
     {2}set columns <columns>{1} - select extra displayed fields in search results:
-         (valid: views comments rating date user likes dislikes category)
+         (valid: views comments rating date time user likes dislikes category)
     {2}set ddir <download direcory>{1} - set where downloads are saved
     {2}set download_command <command>{1} - type {2}help dl-command{1} for info
     {2}set encoder <number>{1} - set encoding preset for downloaded files

--- a/mps_youtube/mpris.py
+++ b/mps_youtube/mpris.py
@@ -519,7 +519,10 @@ def main(connection):
         connection - pipe to communicate with this module
     """
 
-    mprisctl = Mpris2Controller()
+    try:
+        mprisctl = Mpris2Controller()
+    except ImportError: # gi.repository import GLib
+        return
     try:
         mprisctl.acquire()
     except dbus.exceptions.DBusException:

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -355,7 +355,7 @@ def _launch_player(song, songdata, cmd):
     # not supported by encoding
     cmd = [util.xenc(i) for i in cmd]
 
-    arturl = "http://i.ytimg.com/vi/%s/default.jpg" % song.ytid
+    arturl = "https://i.ytimg.com/vi/%s/default.jpg" % song.ytid
     input_file = None
     if ("mplayer" in config.PLAYER.get) or ("mpv" in config.PLAYER.get):
         input_file = _get_input_file()

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -361,6 +361,7 @@ def _launch_player(song, songdata, cmd):
         input_file = _get_input_file()
     sockpath = None
     fifopath = None
+    p = None
 
     try:
         if "mplayer" in config.PLAYER.get:
@@ -420,7 +421,6 @@ def _launch_player(song, songdata, cmd):
         else:
             with open(os.devnull, "w") as devnull:
                 returncode = subprocess.call(cmd, stderr=devnull)
-            p = None
 
         return returncode
 

--- a/mps_youtube/playlist.py
+++ b/mps_youtube/playlist.py
@@ -8,7 +8,6 @@ class Playlist(object):
     def __init__(self, name=None, songs=None):
         """ class members. """
         self.name = name
-        self.creation = time.time()
         self.songs = songs or []
 
     def __len__(self):

--- a/mps_youtube/playlists.py
+++ b/mps_youtube/playlists.py
@@ -35,6 +35,10 @@ def load():
         __main__.Playlist = Playlist
         __main__.Video = Video
 
+        from . import main
+        main.Playlist = Playlist
+        main.Video = Video
+
         with open(g.PLFILE, "rb") as plf:
             g.userpl = pickle.load(plf)
 

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -307,12 +307,13 @@ def real_len(u, alt=False):
 
 
 def yt_datetime(yt_date_time):
-    """ Return a time object and locale formated date string. """
+    """ Return a time object, locale formated date string and locale formatted time string. """
     time_obj = time.strptime(yt_date_time, "%Y-%m-%dT%H:%M:%S.%fZ")
     locale_date = time.strftime("%x", time_obj)
+    locale_time = time.strftime("%X", time_obj)
     # strip first two digits of four digit year
     short_date = re.sub(r"(\d\d\D\d\d\D)20(\d\d)$", r"\1\2", locale_date)
-    return time_obj, short_date
+    return time_obj, short_date, locale_time
 
 
 def parse_multi(choice, end=None):

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -7,6 +7,7 @@ import time
 import subprocess
 import collections
 import unicodedata
+from datetime import datetime, timezone
 
 import pafy
 
@@ -314,6 +315,21 @@ def yt_datetime(yt_date_time):
     # strip first two digits of four digit year
     short_date = re.sub(r"(\d\d\D\d\d\D)20(\d\d)$", r"\1\2", locale_date)
     return time_obj, short_date, locale_time
+
+
+def yt_datetime_local(yt_date_time):
+    """ Return a datetime object, locale converted and formated date string and locale converted and formatted time string. """
+    datetime_obj = datetime.strptime(yt_date_time, "%Y-%m-%dT%H:%M:%S.%fZ")
+    datetime_obj = utc2local(datetime_obj)
+    locale_date = datetime_obj.strftime("%x")
+    locale_time = datetime_obj.strftime("%X")
+    # strip first two digits of four digit year
+    short_date = re.sub(r"(\d\d\D\d\d\D)20(\d\d)$", r"\1\2", locale_date)
+    return datetime_obj, short_date, locale_time
+
+
+def utc2local(utc):
+    return utc.replace(tzinfo=timezone.utc).astimezone(tz=None)
 
 
 def parse_multi(choice, end=None):

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -83,7 +83,7 @@ def has_exefile(filename):
 def dbg(*args):
     """Emit a debug message."""
     # Uses xenc to deal with UnicodeEncodeError when writing to terminal
-    logging.debug(xenc(i) for i in args)
+    logging.debug(*(xenc(i) for i in args))
 
 
 def utf8_replace(txt):

--- a/setup.py
+++ b/setup.py
@@ -60,13 +60,13 @@ options = dict(
             "bundle_files": 1
         }
     },
-    data_files=[("share/mps-youtube", ["LICENSE", "README.rst", "CHANGELOG"])],
+    package_data={"": ["LICENSE", "README.rst", "CHANGELOG"]},
     long_description=open("README.rst").read()
 )
 
 if sys.platform.startswith('linux'):
     # Install desktop file. Required for mpris on Ubuntu
-    options['data_files'].append(('share/applications/', ['mps-youtube.desktop']))
+    options['data_files'] = [('share/applications/', ['mps-youtube.desktop'])]
 
 if os.name == "nt":
     try:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 options = dict(
     name="mps-youtube",
-    version="0.2.7",
+    version="0.2.7.1",
     description="Terminal based YouTube player and downloader",
     keywords=["video", "music", "audio", "youtube", "stream", "download"],
     author="np1",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ options = dict(
     author="np1",
     author_email="np1nagev@gmail.com",
     url="https://github.com/mps-youtube/mps-youtube",
-    download_url="https://github.com/mps-youtube/mps-youtube/archive/v%s.tar.gz" % VERSION
+    download_url="https://github.com/mps-youtube/mps-youtube/archive/v%s.tar.gz" % VERSION,
     packages=['mps_youtube', 'mps_youtube.commands'],
     entry_points={'console_scripts': ['mpsyt = mps_youtube:main.main']},
     install_requires=['pafy >= 0.3.82, != 0.4.0, != 0.4.1, != 0.4.2'],


### PR DESCRIPTION
Feature is simple, can be implemented with a configuration parameter, and would provide a column for the user in the search or playlist results indicating the YouTube video id, much like how it's displayed while streaming. 

This feature would be very handy for those inclined to command and control mpyst via a shell script and the like. 