### PR TITLE
Fix py3.4 dict creation compatibility

### DIFF
--- a/mps_youtube/contentquery.py
+++ b/mps_youtube/contentquery.py
@@ -53,10 +53,10 @@ class ContentQuery:
 
     def _perform_api_call(self):
         # Include nextPageToken if it is set
-        qry = {
-            **{"pageToken": self.nextpagetoken},
+        qry = dict(
+            pageToken=self.nextpagetoken,
             **(self.queries)
-            } if self.nextpagetoken else self.queries
+            ) if self.nextpagetoken else self.queries
 
         # Run query
         util.dbg("CQ.query", qry)


### PR DESCRIPTION
The `{**{'x': 1}}` syntax was introduced in python 3.5 and the `setup.py` currently states 3.4 compatibility.

https://docs.python.org/3/whatsnew/3.5.html#pep-448-additional-unpacking-generalizations
