### PR TITLE
Implements livestream search #634

### DIFF
--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -169,7 +169,7 @@ def channelsearch(q_user):
 
     def run_m(user_id):
         """ Search ! """
-        usersearch_id(*user_id)
+        usersearch_id(*(user_id[0]))
     del g.content
 
     g.content = listview.ListView(columns, QueryObj, run_m)

--- a/mps_youtube/g.py
+++ b/mps_youtube/g.py
@@ -51,6 +51,16 @@ PLFILE = os.path.join(paths.get_config_dir(), "playlist_v2")
 HISTFILE = os.path.join(paths.get_config_dir(), "play_history")
 CACHEFILE = os.path.join(paths.get_config_dir(), "cache_py_" + sys.version[0:5])
 READLINE_FILE = None
+categories = {
+        "film":      1,
+        "autos":     2,
+        "music":    10,
+        "sports":   17,
+        "travel":   19,
+        "gaming":   20,
+        "blogging": 21,
+        "news":     25
+}
 playerargs_defaults = {
     "mpv": {
         "msglevel": {"<0.4": "--msglevel=all=no:statusline=status",

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -42,7 +42,10 @@ def helptext():
     {2}p <number>{1} - switch to page <number>.
 
     {2}album <album title>{1} - Search for matching tracks using album title
-    {2}channels <Channel name> - Search for channels by channelname
+    {2}channels <Channel name>{1} - Search for channels by channelname
+    {2}live <category>{1} - Search for livestreams from a range of categories. 
+    Categories: {2}{3}{1}
+    
     {2}user <username>{1} - list YouTube uploads by <username>.
     {2}user <username>/<query>{1} - as above, but matches <query>.
     {2}userpl <username>{1} - list YouTube playlists created by <username>.
@@ -55,7 +58,7 @@ def helptext():
     {2}r <number>{1} - show videos related to video <number>.
     {2}u <number>{1} - show videos uploaded by uploader of video <number>.
     {2}c <number>{1} - view comments for video <number>
-    """.format(c.ul, c.w, c.y)),
+    """.format(c.ul, c.w, c.y, ", ".join(g.categories.keys()))),
 
         ("edit", "Editing / Manipulating Results", """
     {0}Editing and Manipulating Results{1}

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -33,9 +33,14 @@ def helptext():
     {2}set search_music true{1}  - search only YouTube music category.
 
     {2}/<query>{1} or {2}.<query>{1} to search for videos. e.g., {2}/daft punk{1}
-        [-d {{any,short,medium,long}}] [-a AFTER] search [search ...] {2}/-d short -a day hits{1}
-         AFTER: day, week, month, year, yyyy-mm-dd, yyyy-mm-ddThh:mm:ddZ
-        {2}/ --after 2016-08-11 tweekaz --duration long{1}
+    Search Arguments:
+    {2}-d, --duration{1}    Can be any/short/medium/long
+    {2}-a, --after{1}       Date in {2}YYYY-MM-DD{1} or {2}YYYY-MM-DD{1}T{2}HH:MM{1} format
+    {2}-l, --live{1}        Limit search to livestreams
+    {2}-c, --category{1}    Search within a category, (number or string)
+                      Available categories:
+                      {2}{3}{1}
+
     {2}//<query>{1} or {2}..<query>{1} - search for YouTube playlists. e.g., \
     {2}//80's music{1}
     {2}n{1} and {2}p{1} - continue search to next/previous pages.

--- a/mps_youtube/listview.py
+++ b/mps_youtube/listview.py
@@ -18,7 +18,7 @@ class ListViewItem:
     def __getattr__(self, key):
         return self.data[key] if key in self.data.keys() else None
 
-    def length(self, _):
+    def length(self, _=0):
         """ Returns length of ListViewItem
             A LVI has to return something for length
             even if the item does not have one.
@@ -57,6 +57,29 @@ class ListUser(ListViewItem):
         """ Determines which function will be called on selected items """
         return "ret"
 
+
+class ListLiveStream(ListViewItem):
+    """ Class exposing necessary components of a live stream """
+    # pylint: disable=unused-argument
+    def ytid(self, lngt=10):
+        """ Exposes ytid(string) """
+        return self.data.get("id").get("videoId")
+
+    def ret(self):
+        """ Returns content.video compatible tuple """
+        return (self.ytid(), self.title(), self.length())
+
+    def title(self, lngt=10):
+        """ exposes title """
+        return util.uea_pad(lngt, self.data.get("snippet").get("title"))
+    def description(self, lngt=10):
+        """ exposes description """
+        return util.uea_pad(lngt, self.data.get("snippet").get("description"))
+       
+    @staticmethod
+    def return_field():
+        """ ret """
+        return "ret"
 
 class ListView(content.PaginatedContent):
     """ Content Agnostic Numbered List

--- a/mps_youtube/listview.py
+++ b/mps_youtube/listview.py
@@ -4,7 +4,7 @@
 import re
 import math
 
-from . import c, util, content
+from . import c, g, util, content
 
 
 class ListViewItem:
@@ -136,12 +136,13 @@ class ListView(content.PaginatedContent):
             TODO: Make it so set columns can set "remaining" ?
         """
         # Sums all ints, deal with strings later
-        remaining = (util.getxy().width - 2) - sum(1 + (x['size'] if x['size'] and x['size'].__class__ == int else 0) for x in self.columns)
+        remaining = (util.getxy().width) - sum(1 + (x['size'] if x['size'] and x['size'].__class__ == int else 0) for x in self.columns) - (len(self.columns))
         lengthsize = 0
         if "length" in [x['size'] for x in self.columns]:
             max_l = max((getattr(x, "length")() for x in self.objects))
             lengthsize = 8 if max_l > 35999 else 7
             lengthsize = 6 if max_l < 6000 else lengthsize
+
         for col in self.columns:
             if col['size'] == "remaining":
                 col['size'] = remaining - lengthsize
@@ -168,6 +169,7 @@ class ListView(content.PaginatedContent):
                     data.append("%2d" % (num + (self.views_per_page() * self.page) + 1))
                 else:
                     field = getattr(obj, field)(fieldsize)
+                    field = str(field) if field.__class__ != str else field
                     if len(field) > fieldsize:
                         field = field[:fieldsize]
                     else:
@@ -182,11 +184,19 @@ class ListView(content.PaginatedContent):
         """ Handles what happends when a user selects something from the list
             Currently this functions hooks into commands/play
         """
-        uid = int(choice.split(",")[0].strip()) - 1
-        attr = getattr(self.objects[uid],
-                       self.objects.datatype.return_field(), None)
 
-        return self.func(attr())
+        uids = []
+        for splitted_choice in choice.split(","):
+            cho = splitted_choice.strip()
+            if cho.isdigit():
+                uids.append(int(cho) - 1)
+            else:
+                cho = cho.split("-")
+                if cho[0].isdigit() and cho[1].isdigit():
+                    uids += list(range(int(cho[0]) - 1, int(cho[1])))
+
+        var = getattr(self.object_type, "return_field")()
+        self.func([getattr(self.objects[x], var)() for x in uids])
 
     def views_per_page(self):
         """ Determines how many views can be per page


### PR DESCRIPTION
Implements a simple livestream category search using the "live" command as described in the issue #634.

I reckon we could add a livestream filter to the search rather than have live take more arguments