### PR TITLE
FIX - AttributeError: 'int' object has no attribute 'encode' 

### DIFF
--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -96,6 +96,7 @@ def utf8_replace(txt):
     :rtype: str
     """
     sse = sys.stdout.encoding
+    txt = str(txt)
     txt = txt.encode(sse, "replace").decode(sse)
     return txt
 


### PR DESCRIPTION
Python 3.6 windows 
Traceback (most recent call last):
  File "mpsyt", line 2, in <module>
    import mps_youtube.main
  File "C:\Users\XXXXXXXXXX\projects\mps-youtube\mps_youtube\__init__.py", line 8, in <module>
    init.init()
  File "C:\Users\XXXXXXXXXX\projects\mps-youtube\mps_youtube\init.py", line 58, in init
    cache.load()
  File "C:\Users\XXXXXXXXXX\projects\mps-youtube\mps_youtube\cache.py", line 41, in load
    streams.prune()
  File "C:\Users\XXXXXXXXXX\projects\mps-youtube\mps_youtube\streams.py", line 35, in prune
    util.dbg(c.b + "paf: %s, streams: %s%s", len(g.pafs), len(g.streams), c.w)
  File "C:\Users\XXXXXXXXXX\projects\mps-youtube\mps_youtube\util.py", line 86, in dbg
    logging.debug(*(xenc(i) for i in args))
  File "C:\Users\XXXXXXXXXX\projects\mps-youtube\mps_youtube\util.py", line 86, in <genexpr>
    logging.debug(*(xenc(i) for i in args))
  File "C:\Users\XXXXXXXXXX\projects\mps-youtube\mps_youtube\util.py", line 105, in xenc
    return utf8_replace(stuff) if not_utf8_environment else stuff
  File "C:\Users\XXXXXXXXXX\projects\mps-youtube\mps_youtube\util.py", line 99, in utf8_replace
    txt = txt.encode(sse, "replace").decode(sse)
AttributeError: 'int' object has no attribute 'encode'