### PR TITLE
Add new configuration option: video_format

### DIFF
--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -304,6 +304,8 @@ class _Config:
             ConfigItem("download_command", ''),
             ConfigItem("audio_format", "auto",
                 allowed_values="auto webm m4a".split()),
+            ConfigItem("video_format", "auto",
+                allowed_values="auto webm mp4 3gp".split()),
             ConfigItem("api_key", "AIzaSyCIM4EzNqi1in22f4Z3Ru3iYvLaY8tc3bo",
                 check_fn=check_api_key),
             ConfigItem("autoplay", False),

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -231,6 +231,7 @@ def helptext():
     {2}set window_pos <top|bottom>-<left|right>{1} - set player window position
     {2}set window_size <number>x<number>{1} - set player window width & height
     {2}set audio_format <auto|m4a|webm>{1} - set default music audio format
+    {2}set video_format <auto|mp4|webm|3gp>{1} - set default music video format
     {2}set api_key <key>{1} - use a different API key for accessing the YouTube Data API
     {2}set set_title true|false{1} - change window title
     """.format(c.ul, c.w, c.y, '\n{0}set max_results <number>{1} - show <number> re'

--- a/mps_youtube/streams.py
+++ b/mps_youtube/streams.py
@@ -105,6 +105,15 @@ def select(slist, q=0, audio=False, m4a_ok=True, maxres=None):
         streams = sorted(streams, key=getbitrate, reverse=True)
     else:
         streams = [x for x in slist if x['mtype'] == "normal" and okres(x)]
+        if not config.VIDEO_FORMAT.get == "auto":
+            if config.VIDEO_FORMAT.get == "mp4":
+                streams = [x for x in streams if x['ext'] == "mp4"]
+            if config.VIDEO_FORMAT.get == "webm":
+                streams = [x for x in streams if x['ext'] == "webm"]
+            if config.VIDEO_FORMAT.get == "3gp":
+                streams = [x for x in streams if x['ext'] == "3gp"]
+            if not streams:
+                streams = [x for x in slist if x['mtype'] == "normal" and okres(x)]
         streams = sorted(streams, key=getq, reverse=True)
 
     util.dbg("select stream, q: %s, audio: %s, len: %s", q, audio, len(streams))


### PR DESCRIPTION
Add the video_format configuration option, to let the user choose the
preferred video format for downloads, in a way similar to the current
audio_format option. See https://github.com/mps-youtube/mps-youtube/issues/529