### PR TITLE
Preserve mpv-player options and cache when using repeat mode

### DIFF
--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -39,7 +39,7 @@ def play_range(songlist, shuffle=False, repeat=False, override=False):
         if config.SET_TITLE.get:
             util.set_window_title(song.title + " - mpsyt")
         try:
-            returncode = _playsong(song, override=override)
+            returncode = _playsong(song, override=override, repeat=repeat)
 
         except KeyboardInterrupt:
             logging.info("Keyboard Interrupt")
@@ -131,7 +131,7 @@ def _mplayer_help(short=True):
     return lines.format(c.g, c.w)
 
 
-def _playsong(song, failcount=0, override=False):
+def _playsong(song, failcount=0, override=False, repeat=False):
     """ Play song using config.PLAYER called with args config.PLAYERARGS."""
     # pylint: disable=R0911,R0912
     if not config.PLAYER.get or not util.has_exefile(config.PLAYER.get):
@@ -160,7 +160,7 @@ def _playsong(song, failcount=0, override=False):
         elif failcount < g.max_retries:
             util.dbg("--ioerror - trying next stream")
             failcount += 1
-            return _playsong(song, failcount=failcount, override=override)
+            return _playsong(song, failcount=failcount, override=override, repeat=repeat)
 
         elif "pafy" in str(e):
             g.message = str(e) + " - " + song.ytid
@@ -195,7 +195,7 @@ def _playsong(song, failcount=0, override=False):
         util.dbg("----htterror in _playsong call to gen_real_args %s", str(e))
         if failcount < g.max_retries:
             failcount += 1
-            return _playsong(song, failcount=failcount, override=override)
+            return _playsong(song, failcount=failcount, override=override, repeat=repeat)
         else:
             g.message = str(e)
             return
@@ -213,7 +213,7 @@ def _playsong(song, failcount=0, override=False):
     songdata = "%s; %s; %s Mb" % songdata
     screen.writestatus(songdata)
 
-    cmd = _generate_real_playerargs(song, override, stream, video)
+    cmd = _generate_real_playerargs(song, override, stream, video, repeat)
     returncode = _launch_player(song, songdata, cmd)
     failed = returncode not in (0, 42, 43)
 
@@ -223,13 +223,13 @@ def _playsong(song, failcount=0, override=False):
         screen.writestatus("error: retrying")
         time.sleep(1.2)
         failcount += 1
-        return _playsong(song, failcount=failcount, override=override)
+        return _playsong(song, failcount=failcount, override=override, repeat=repeat)
 
     history.add(song)
     return returncode
 
 
-def _generate_real_playerargs(song, override, stream, isvideo):
+def _generate_real_playerargs(song, override, stream, isvideo, repeat):
     """ Generate args for player command.
 
     Return args.
@@ -300,6 +300,9 @@ def _generate_real_playerargs(song, override, stream, isvideo):
                 else:
                     util.list_update("--really-quiet", args, remove=True)
                     util.list_update(msglevel, args)
+
+            if repeat:
+                util.list_update("--loop-file", args)
 
     elif "vlc" in config.PLAYER.get:
         util.list_update("--play-and-exit", args)


### PR DESCRIPTION
This feature only come in action when using `repeat mode` with `mpv-player` and `len(songlist) == 1`. I tried something like this with `mplayer` too but it resets everything whenever the song starts over again. So, haven't messed up anything with `mplayer`. This PR modifies and works only for `mpv-player`.

Partially fix #658 and #659.