### PR TITLE
Fixes #663

### DIFF
--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -307,7 +307,7 @@ def search(term):
     logging.info("search for %s", term)
     query = generate_search_qs(term, videoDuration=video_duration, after=after,
                                category=args.category, is_live=args.live)
-    
+
     msg = "Search results for %s%s%s" % (c.y, term, c.w)
     failmsg = "Found nothing for %s%s%s" % (c.y, term, c.w)
     _search(term, query, msg, failmsg)
@@ -429,7 +429,6 @@ def get_track_id_from_json(item):
             return node
     return ''
 
-
 def get_tracks_from_json(jsons):
     """ Get search results from API response """
 
@@ -438,9 +437,15 @@ def get_tracks_from_json(jsons):
         util.dbg("got unexpected data or no search results")
         return ()
 
+    ids = []
     # fetch detailed information about items from videos API
+    for item in items:
+        if item['id']['kind'] == 'youtube#video':
+            ids.append(get_track_id_from_json(item))
+    print(ids)
+
     qs = {'part':'contentDetails,statistics,snippet',
-          'id': ','.join([get_track_id_from_json(i) for i in items])}
+          'id': ','.join(ids)}
 
     wdata = pafy.call_gdata('videos', qs)
 

--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -443,7 +443,6 @@ def get_tracks_from_json(jsons):
     for item in items:
         if item['id']['kind'] == 'youtube#video':
             ids.append(get_track_id_from_json(item))
-    print(ids)
 
     qs = {'part':'contentDetails,statistics,snippet',
           'id': ','.join(ids)}

--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -271,7 +271,7 @@ def livestream_category_search(term):
               {"name": "idx", "size": 3, "heading": "Num"},
               {"name": "title", "size": 40, "heading": "Title"},
               {"name": "description", "size": "remaining", "heading": "Description"},
-              ] 
+              ]
 
     def start_stream(returned):
         songs = Playlist("Search Results", [Video(*x) for x in returned])
@@ -353,8 +353,10 @@ def pl_search(term, page=0, splash=True, is_user=False):
             del qs['videoCategoryId'] # Incompatable with type=playlist
 
         pldata = pafy.call_gdata('search', qs)
+
         id_list = [i.get('id', {}).get('playlistId')
-                    for i in pldata.get('items', ())]
+                    for i in pldata.get('items', ())
+                    if i['id']['kind'] == 'youtube#playlist']
 
         result_count = min(pldata['pageInfo']['totalResults'], 500)
 
@@ -438,14 +440,13 @@ def get_tracks_from_json(jsons):
         util.dbg("got unexpected data or no search results")
         return ()
 
-    ids = []
     # fetch detailed information about items from videos API
-    for item in items:
-        if item['id']['kind'] == 'youtube#video':
-            ids.append(get_track_id_from_json(item))
+    id_list = [get_track_id_from_json(i)
+                for i in items
+                if i['id']['kind'] == 'youtube#video']
 
     qs = {'part':'contentDetails,statistics,snippet',
-          'id': ','.join(ids)}
+          'id': ','.join(id_list)}
 
     wdata = pafy.call_gdata('videos', qs)
 

--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -429,6 +429,7 @@ def get_track_id_from_json(item):
             return node
     return ''
 
+
 def get_tracks_from_json(jsons):
     """ Get search results from API response """
 


### PR DESCRIPTION
Fixes #663.

The problem was `mpsyt` attempting to parse a channel result using `get_track_id_from_json(item)` whereas the function expects a video result as parameter. I changed the code a bit such that only video results are passed into the function and anything else gets ignored.

P.S. Sorry for the unnecessary commits, you should probably squash them.