### PR TITLE
Load tracks from a Spotify playlist

### DIFF
--- a/mps_youtube/commands/__init__.py
+++ b/mps_youtube/commands/__init__.py
@@ -23,5 +23,5 @@ def command(regex):
 
 
 # Placed at bottom to deal with cyclic imports
-from . import download, search, album_search, misc, config, local_playlist
+from . import download, search, album_search, spotify_playlist, misc, config, local_playlist
 from . import play, songlist, generate_playlist

--- a/mps_youtube/commands/album_search.py
+++ b/mps_youtube/commands/album_search.py
@@ -225,11 +225,6 @@ def search_album(term):
         show_message("Album '%s' not found!" % term)
         return
 
-    out = "'%s' by %s%s%s\n\n" % (album['title'],
-                                  c.g, album['artist'], c.w)
-    out += ("[Enter] to continue, [q] to abort, or enter artist name for:\n"
-            "    %s" % (c.y + term + c.w + "\n"))
-
     prompt = "Artist? [%s] > " % album['artist']
     util.xprint(prompt, end="")
     artistentry = input().strip()

--- a/mps_youtube/commands/spotify_playlist.py
+++ b/mps_youtube/commands/spotify_playlist.py
@@ -48,7 +48,31 @@ def grab_playlist(spotify, playlist):
         else:
             break
 
-    # TODO
+    if playlists['total'] == 0:
+        return
+
+    owner_id = playlist['owner']['id']
+    playlist_id = playlist['id']
+    results = spotify.user_playlist(owner_id, playlist_id, fields='tracks,next')
+
+    all_tracks = []
+    tracks = results['tracks']
+    while True:
+        for item in tracks['items']:
+            track = item['track']
+            try:
+                #util.xprint(track['external_urls']['spotify'])
+                all_tracks.append(track)
+            except KeyError:
+                pass
+        # 1 page = 50 results
+        # check if there are more pages
+        if tracks['next']:
+            tracks = spotify.next(tracks)
+        else:
+            break
+
+    return all_tracks
 
 
 def show_message(message, col=c.r, update=False):
@@ -260,13 +284,13 @@ def search_playlist(term):
     token = credentials.get_access_token()
     spotify = spotipy.Spotify(auth=token)
 
-    grab_playlist(spotify, 'https://open.spotify.com/user/1110716798/playlist/2NwWoITrXtgxDBAvzGIz52')
-    exit()
-    playlist = _get_mb_album(term)
+    tracks = grab_playlist(spotify, 'https://open.spotify.com/user/1110716798/playlist/2NwWoITrXtgxDBAvzGIz52')
 
-    if not playlist:
+    if not tracks:
         show_message("Playlist '%s' not found!" % term)
         return
+
+    playlist = _get_mb_album(term)
 
     out = "'%s' by %s%s%s\n\n" % (album['title'],
                                   c.g, album['artist'], c.w)

--- a/mps_youtube/commands/spotify_playlist.py
+++ b/mps_youtube/commands/spotify_playlist.py
@@ -1,0 +1,342 @@
+import spotipy
+import spotipy.oauth2 as oauth2
+import re
+import time
+import difflib
+from urllib.request import build_opener
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from xml.etree import ElementTree as ET
+
+import pafy
+
+from .. import c, g, screen, __version__, __url__, content, config, util
+from . import command
+from .songlist import paginatesongs
+from .search import generate_search_qs, get_tracks_from_json
+
+
+
+def generate_credentials():
+    """Generate the token. Please respect these credentials :)"""
+    credentials = oauth2.SpotifyClientCredentials(
+        client_id='4fe3fecfe5334023a1472516cc99d805',
+        client_secret='0f02b7c483c04257984695007a4a8d5c')
+    return credentials
+
+
+def grab_playlist(spotify, playlist):
+    if '/' in playlist:
+        if playlist.endswith('/'):
+            playlist = playlist[:-1]
+        splits = playlist.split('/')
+    else:
+        splits = playlist.split(':')
+
+    username = splits[-3]
+    playlist_id = splits[-1]
+    playlists = spotify.user_playlists(username)
+
+    while True:
+        for playlist in playlists['items']:
+            if not playlist['name'] == None:
+                if playlist['id'] == playlist_id:
+                    playlists['next'] = None
+                    break
+        if playlists['next']:
+            playlists = spotify.next(playlists)
+        else:
+            break
+
+    # TODO
+
+
+def show_message(message, col=c.r, update=False):
+    """ Show message using col, update screen if required. """
+    g.content = content.generate_songlist_display()
+    g.message = col + message + c.w
+
+    if update:
+        screen.update()
+
+
+def _do_query(url, query, err='query failed', report=False):
+    """ Perform http request using mpsyt user agent header.
+
+    if report is True, return whether response is from memo
+
+    """
+    # create url opener
+    ua = "mps-youtube/%s ( %s )" % (__version__, __url__)
+    mpsyt_opener = build_opener()
+    mpsyt_opener.addheaders = [('User-agent', ua)]
+
+    # convert query to sorted list of tuples (needed for consistent url_memo)
+    query = [(k, query[k]) for k in sorted(query.keys())]
+    url = "%s?%s" % (url, urlencode(query))
+
+    try:
+        wdata = mpsyt_opener.open(url).read().decode()
+
+    except (URLError, HTTPError) as e:
+        g.message = "%s: %s (%s)" % (err, e, url)
+        g.content = content.logo(c.r)
+        return None if not report else (None, False)
+
+    return wdata if not report else (wdata, False)
+
+
+def _best_song_match(songs, title, duration, titleweight, durationweight):
+    """ Select best matching song based on title, length.
+
+    Score from 0 to 1 where 1 is best. titleweight and durationweight
+    parameters added to enable function usage when duration can't be guessed
+
+    """
+    # pylint: disable=R0914
+    seqmatch = difflib.SequenceMatcher
+
+    def variance(a, b):
+        """ Return difference ratio. """
+        return float(abs(a - b)) / max(a, b)
+
+    candidates = []
+
+    ignore = "music video lyrics new lyrics video audio".split()
+    extra = "official original vevo".split()
+
+    for song in songs:
+        dur, tit = int(song.length), song.title
+        util.dbg("Title: %s, Duration: %s", tit, dur)
+
+        for word in extra:
+            if word in tit.lower() and word not in title.lower():
+                pattern = re.compile(word, re.I)
+                tit = pattern.sub("", tit)
+
+        for word in ignore:
+            if word in tit.lower() and word not in title.lower():
+                pattern = re.compile(word, re.I)
+                tit = pattern.sub("", tit)
+
+        replacechars = re.compile(r"[\]\[\)\(\-]")
+        tit = replacechars.sub(" ", tit)
+        multiple_spaces = re.compile(r"(\s)(\s*)")
+        tit = multiple_spaces.sub(r"\1", tit)
+
+        title_score = seqmatch(None, title.lower(), tit.lower()).ratio()
+        duration_score = 1 - variance(duration, dur)
+        util.dbg("Title score: %s, Duration score: %s", title_score,
+                 duration_score)
+
+        # apply weightings
+        score = duration_score * durationweight + title_score * titleweight
+        candidates.append((score, song))
+
+    best_score, best_song = max(candidates, key=lambda x: x[0])
+    percent_score = int(100 * best_score)
+    return best_song, percent_score
+
+
+def _match_tracks(artist, title, mb_tracks):
+    """ Match list of tracks in mb_tracks by performing multiple searches. """
+    # pylint: disable=R0914
+    util.dbg("artists is %s", artist)
+    util.dbg("title is %s", title)
+    title_artist_str = c.g + title + c.w, c.g + artist + c.w
+    util.xprint("\nSearching for %s by %s\n\n" % title_artist_str)
+
+    def dtime(x):
+        """ Format time to M:S. """
+        return time.strftime('%M:%S', time.gmtime(int(x)))
+
+    # do matching
+    for track in mb_tracks:
+        ttitle = track['title']
+        length = track['length']
+        util.xprint("Search :  %s%s - %s%s - %s" % (c.y, artist, ttitle, c.w,
+                                                    dtime(length)))
+        q = "%s %s" % (artist, ttitle)
+        w = q = ttitle if artist == "Various Artists" else q
+        query = generate_search_qs(w, 0)
+        util.dbg(query)
+
+        # perform fetch
+        wdata = pafy.call_gdata('search', query)
+        results = get_tracks_from_json(wdata)
+
+        if not results:
+            util.xprint(c.r + "Nothing matched :(\n" + c.w)
+            continue
+
+        s, score = _best_song_match(
+            results, artist + " " + ttitle, length, .5, .5)
+        cc = c.g if score > 85 else c.y
+        cc = c.r if score < 75 else cc
+        util.xprint("Matched:  %s%s%s - %s \n[%sMatch confidence: "
+                    "%s%s]\n" % (c.y, s.title, c.w, util.fmt_time(s.length),
+                                 cc, score, c.w))
+        yield s
+
+
+def _get_mb_tracks(albumid):
+    """ Get track listing from MusicBraiz by album id. """
+    ns = {'mb': 'http://musicbrainz.org/ns/mmd-2.0#'}
+    url = "http://musicbrainz.org/ws/2/release/" + albumid
+    query = {"inc": "recordings"}
+    wdata = _do_query(url, query, err='album search error')
+
+    if not wdata:
+        return None
+
+    root = ET.fromstring(wdata)
+    tlist = root.find("./mb:release/mb:medium-list/mb:medium/mb:track-list",
+                      namespaces=ns)
+    mb_songs = tlist.findall("mb:track", namespaces=ns)
+    tracks = []
+    path = "./mb:recording/mb:"
+
+    for track in mb_songs:
+
+        try:
+            title, length, rawlength = "unknown", 0, 0
+            title = track.find(path + "title", namespaces=ns).text
+            rawlength = track.find(path + "length", namespaces=ns).text
+            length = int(round(float(rawlength) / 1000))
+
+        except (ValueError, AttributeError):
+            util.xprint("not found")
+
+        tracks.append(dict(title=title, length=length, rawlength=rawlength))
+
+    return tracks
+
+
+def _get_mb_album(albumname, **kwa):
+    """ Return artist, album title and track count from MusicBrainz. """
+    url = "http://musicbrainz.org/ws/2/release/"
+    qargs = dict(
+        release='"%s"' % albumname,
+        primarytype=kwa.get("primarytype", "album"),
+        status=kwa.get("status", "official"))
+    qargs.update({k: '"%s"' % v for k, v in kwa.items()})
+    qargs = ["%s:%s" % item for item in qargs.items()]
+    qargs = {"query": " AND ".join(qargs)}
+    g.message = "Album search for '%s%s%s'" % (c.y, albumname, c.w)
+    wdata = _do_query(url, qargs)
+
+    if not wdata:
+        return None
+
+    ns = {'mb': 'http://musicbrainz.org/ns/mmd-2.0#'}
+    root = ET.fromstring(wdata)
+    rlist = root.find("mb:release-list", namespaces=ns)
+
+    if int(rlist.get('count')) == 0:
+        return None
+
+    album = rlist.find("mb:release", namespaces=ns)
+    artist = album.find("./mb:artist-credit/mb:name-credit/mb:artist",
+                        namespaces=ns).find("mb:name", namespaces=ns).text
+    title = album.find("mb:title", namespaces=ns).text
+    aid = album.get('id')
+    return dict(artist=artist, title=title, aid=aid)
+
+
+@command(r'splaylist\s(.*[-_a-zA-Z0-9].*)')
+def search_playlist(term):
+    """Search for Spotify playlist. """
+    # pylint: disable=R0914,R0912
+    if not term:
+        show_message("Enter playlist url:", c.g, update=True)
+        term = input("> ")
+
+        if not term or len(term) < 2:
+            g.message = c.r + "Not enough input!" + c.w
+            g.content = content.generate_songlist_display()
+            return
+
+    credentials = generate_credentials()
+    token = credentials.get_access_token()
+    spotify = spotipy.Spotify(auth=token)
+
+    grab_playlist(spotify, 'https://open.spotify.com/user/1110716798/playlist/2NwWoITrXtgxDBAvzGIz52')
+    exit()
+    playlist = _get_mb_album(term)
+
+    if not playlist:
+        show_message("Playlist '%s' not found!" % term)
+        return
+
+    out = "'%s' by %s%s%s\n\n" % (album['title'],
+                                  c.g, album['artist'], c.w)
+    out += ("[Enter] to continue, [q] to abort, or enter artist name for:\n"
+            "    %s" % (c.y + term + c.w + "\n"))
+
+    prompt = "Artist? [%s] > " % album['artist']
+    util.xprint(prompt, end="")
+    artistentry = input().strip()
+
+    if artistentry:
+
+        if artistentry == "q":
+            show_message("Album search abandoned!")
+            return
+
+        album = _get_mb_album(term, artist=artistentry)
+
+        if not album:
+            show_message("Album '%s' by '%s' not found!" % (term, artistentry))
+            return
+
+    title, artist = album['title'], album['artist']
+    mb_tracks = _get_mb_tracks(album['aid'])
+
+    if not mb_tracks:
+        show_message("Album '%s' by '%s' has 0 tracks!" % (title, artist))
+        return
+
+    msg = "%s%s%s by %s%s%s\n\n" % (c.g, title, c.w, c.g, artist, c.w)
+    msg += "Enter to begin matching or [q] to abort"
+    g.message = msg
+    g.content = "Tracks:\n"
+    for n, track in enumerate(mb_tracks, 1):
+        g.content += "%02s  %s" % (n, track['title'])
+        g.content += "\n"
+
+    screen.update()
+    entry = input("Continue? [Enter] > ")
+
+    if entry == "":
+        pass
+
+    else:
+        show_message("Album search abandoned!")
+        return
+
+    songs = []
+    screen.clear()
+    itt = _match_tracks(artist, title, mb_tracks)
+
+    stash = config.SEARCH_MUSIC.get, config.ORDER.get
+    config.SEARCH_MUSIC.value = True
+    config.ORDER.value = "relevance"
+
+    try:
+        songs.extend(itt)
+
+    except KeyboardInterrupt:
+        util.xprint("%sHalted!%s" % (c.r, c.w))
+
+    finally:
+        config.SEARCH_MUSIC.value, config.ORDER.value = stash
+
+    if songs:
+        util.xprint("\n%s / %s songs matched" % (len(songs), len(mb_tracks)))
+        input("Press Enter to continue")
+
+    msg = "Contents of album %s%s - %s%s %s(%d/%d)%s:" % (
+        c.y, artist, title, c.w, c.b, len(songs), len(mb_tracks), c.w)
+    failmsg = "Found no album tracks for %s%s%s" % (c.y, title, c.w)
+
+    paginatesongs(songs, msg=msg, failmsg=failmsg)

--- a/mps_youtube/commands/spotify_playlist.py
+++ b/mps_youtube/commands/spotify_playlist.py
@@ -15,8 +15,8 @@ from .search import generate_search_qs, get_tracks_from_json
 def generate_credentials():
     """Generate the token. Please respect these credentials :)"""
     credentials = oauth2.SpotifyClientCredentials(
-        client_id='4fe3fecfe5334023a1472516cc99d805',
-        client_secret='0f02b7c483c04257984695007a4a8d5c')
+        client_id='6451e12933bb49ed8543d41e3296a88d',
+        client_secret='40ef54678fe441bd9acd66f5d5c34e69')
     return credentials
 
 

--- a/mps_youtube/commands/spotify_playlist.py
+++ b/mps_youtube/commands/spotify_playlist.py
@@ -309,5 +309,5 @@ def search_playlist(term, spotify=None):
         paginatesongs(songs, msg=msg, failmsg=failmsg)
 
     else:
-        g.message = "pyperclip module must be installed for Spotify support\n"
+        g.message = "spotipy module must be installed for Spotify support\n"
         g.message += "see https://pypi.python.org/pypi/spotipy/"

--- a/mps_youtube/commands/spotify_playlist.py
+++ b/mps_youtube/commands/spotify_playlist.py
@@ -72,7 +72,7 @@ def grab_playlist(spotify, playlist):
         else:
             break
 
-    return all_tracks
+    return (playlist, all_tracks)
 
 
 def show_message(message, col=c.r, update=False):
@@ -284,48 +284,26 @@ def search_playlist(term):
     token = credentials.get_access_token()
     spotify = spotipy.Spotify(auth=token)
 
-    tracks = grab_playlist(spotify, 'https://open.spotify.com/user/1110716798/playlist/2NwWoITrXtgxDBAvzGIz52')
+    playlist, tracks = grab_playlist(spotify, 'https://open.spotify.com/user/1110716798/playlist/2NwWoITrXtgxDBAvzGIz52')
 
     if not tracks:
         show_message("Playlist '%s' not found!" % term)
         return
 
-    playlist = _get_mb_album(term)
+    out = "'%s' by %s%s%s\n\n" % (playlist['name'],
+                                  c.g, playlist['owner']['id'], c.w)
 
-    out = "'%s' by %s%s%s\n\n" % (album['title'],
-                                  c.g, album['artist'], c.w)
-    out += ("[Enter] to continue, [q] to abort, or enter artist name for:\n"
-            "    %s" % (c.y + term + c.w + "\n"))
-
-    prompt = "Artist? [%s] > " % album['artist']
-    util.xprint(prompt, end="")
-    artistentry = input().strip()
-
-    if artistentry:
-
-        if artistentry == "q":
-            show_message("Album search abandoned!")
-            return
-
-        album = _get_mb_album(term, artist=artistentry)
-
-        if not album:
-            show_message("Album '%s' by '%s' not found!" % (term, artistentry))
-            return
-
-    title, artist = album['title'], album['artist']
-    mb_tracks = _get_mb_tracks(album['aid'])
-
-    if not mb_tracks:
-        show_message("Album '%s' by '%s' has 0 tracks!" % (title, artist))
+    if not playlist['tracks']['total']:
+        show_message("Playlist '%s' by '%s' has 0 tracks!" % (playlist['name'], playlist['owner']['id']))
         return
 
-    msg = "%s%s%s by %s%s%s\n\n" % (c.g, title, c.w, c.g, artist, c.w)
+    msg = "%s%s%s by %s%s%s\n\n" % (c.g, playlist['name'], c.w, c.g, playlist['owner']['id'], c.w)
     msg += "Enter to begin matching or [q] to abort"
     g.message = msg
     g.content = "Tracks:\n"
-    for n, track in enumerate(mb_tracks, 1):
-        g.content += "%02s  %s" % (n, track['title'])
+    for n, track in enumerate(tracks, 1):
+        trackname = track['artists'][0]['name'] + ' - ' + track['name']
+        g.content += "%02s  %s" % (n, trackname)
         g.content += "\n"
 
     screen.update()

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ options = dict(
     download_url="https://github.com/mps-youtube/mps-youtube/archive/v%s.tar.gz" % VERSION,
     packages=['mps_youtube', 'mps_youtube.commands', 'mps_youtube.listview'],
     entry_points={'console_scripts': ['mpsyt = mps_youtube:main.main']},
-    install_requires=['pafy >= 0.3.82, != 0.4.0, != 0.4.1, != 0.4.2', 'spotipy >= 2.4.4'],
+    install_requires=['pafy >= 0.3.82, != 0.4.0, != 0.4.1, != 0.4.2'],
     classifiers=[
         "Topic :: Utilities",
         "Topic :: Internet :: WWW/HTTP",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ options = dict(
     download_url="https://github.com/mps-youtube/mps-youtube/archive/v%s.tar.gz" % VERSION,
     packages=['mps_youtube', 'mps_youtube.commands', 'mps_youtube.listview'],
     entry_points={'console_scripts': ['mpsyt = mps_youtube:main.main']},
-    install_requires=['pafy >= 0.3.82, != 0.4.0, != 0.4.1, != 0.4.2'],
+    install_requires=['pafy >= 0.3.82, != 0.4.0, != 0.4.1, != 0.4.2', 'spotipy >= 2.4.4],
     classifiers=[
         "Topic :: Utilities",
         "Topic :: Internet :: WWW/HTTP",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ options = dict(
     download_url="https://github.com/mps-youtube/mps-youtube/archive/v%s.tar.gz" % VERSION,
     packages=['mps_youtube', 'mps_youtube.commands', 'mps_youtube.listview'],
     entry_points={'console_scripts': ['mpsyt = mps_youtube:main.main']},
-    install_requires=['pafy >= 0.3.82, != 0.4.0, != 0.4.1, != 0.4.2', 'spotipy >= 2.4.4],
+    install_requires=['pafy >= 0.3.82, != 0.4.0, != 0.4.1, != 0.4.2', 'spotipy >= 2.4.4'],
     classifiers=[
         "Topic :: Utilities",
         "Topic :: Internet :: WWW/HTTP",


### PR DESCRIPTION
This PR adds 2 commands; `splaylist` and `suser`.

`splaylist <link to spotify playlist>` loads tracks from Spotify playlist and then attempts to match them on YouTube (similar to album search).

`suser <spotify username>` takes Spotify username and shows all the public playlists owned by the user and lets you choose the playlist you want to load. It then attempts to match tracks on YouTube.

example:

```
splaylist https://open.spotify.com/user/11124160165/playlist/1lKPLKqfYb6k6ENiRfqcVd
```
```
suser sirsirington
```

These features require a new dependency [spotipy](https://github.com/plamere/spotipy), which is wrapper for the Spotify Web API.

I wanted to have this functionality for a long time, thought people might find it useful too.