### PR TITLE
Implement history export function

### DIFF
--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -332,8 +332,9 @@ def clear_history():
 @command(r'history export')
 def export_history():
     """ Export the user's play history to play_history.txt. """
-    with open(g.HISTFILE + '.txt', 'w') as f:                                     
-        for song in g.userhist['history'].songs:
-            f.write("%s %s\n" % (song.ytid, song.title))
-    g.message = "History exported to: " + g.HISTFILE + '.txt'
+    if 'history' in g.userhist:
+        history.export()
+        g.message = "History exported to: " + g.HISTFILE + ".txt"
+    else:
+        g.message = "No history to export."
     g.content = logo()

--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -327,3 +327,13 @@ def clear_history():
     history.save()
     g.message = "History cleared"
     g.content = logo()
+
+
+@command(r'history export')
+def export_history():
+    """ Export the user's play history to play_history.txt. """
+    with open(g.HISTFILE + '.txt', 'w') as f:                                     
+        for song in g.userhist['history'].songs:
+            f.write("%s %s\n" % (song.ytid, song.title))
+    g.message = "History exported to: " + g.HISTFILE + '.txt'
+    g.content = logo()

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -180,6 +180,8 @@ def helptext():
         {2}history{1} - displays a list of songs contained in history
         {2}history clear{1} - clears the song history
         {2}history recent{1} - displays a list of recent played songs
+        {2}history export{1} - exports song history to a human readable file
+                format: <YouTube ID> <Song name>
     """.format(c.ul, c.w, c.y)),
 
         ("invoke", "Invocation Parameters", """

--- a/mps_youtube/history.py
+++ b/mps_youtube/history.py
@@ -36,3 +36,10 @@ def save():
         pickle.dump(g.userhist, hlf, protocol=2)
 
     dbg(c.r + "History saved\n---" + c.w)
+
+
+def export():
+    """ Export history to human readable file. """
+    with open(g.HISTFILE + '.txt', 'w') as f:                                     
+        for song in g.userhist['history'].songs:
+            f.write("%s %s\n" % (song.ytid, song.title))

--- a/mps_youtube/history.py
+++ b/mps_youtube/history.py
@@ -42,4 +42,4 @@ def export():
     """ Export history to human readable file. """
     with open(g.HISTFILE + '.txt', 'w') as f:                                     
         for song in g.userhist['history'].songs:
-            f.write("%s %s\n" % (song.ytid, song.title))
+            f.write("%s\t%s\n" % (song.ytid, song.title))


### PR DESCRIPTION
This adds `history export` as a way to export the song history to a human readable file called `play_history.txt`. This was requested in #667.