### PR TITLE
Do not clear songlist after playback

### DIFF
--- a/mps_youtube/commands/play.py
+++ b/mps_youtube/commands/play.py
@@ -94,8 +94,9 @@ def play(pre, choice, post=""):
         try:
             play_range(songlist, shuffle, repeat, override)
         except KeyboardInterrupt:
-            g.content = content.generate_songlist_display()
             return
+        finally:
+            g.content = content.generate_songlist_display()
 
         if config.AUTOPLAY.get:
             related(selection.pop())


### PR DESCRIPTION
The piece of code that would display the songlist after playback would only run on `KeyboardInterrupt` event. I Added it under the `finally` block such that it executes under both smooth playbacks and `KeyboardInterrupt` events.

Fixes #683.