### PR TITLE
Fix absolute seek through MPRIS with mpv v0.24.0

### DIFF
--- a/mps_youtube/mpris.py
+++ b/mps_youtube/mpris.py
@@ -432,7 +432,7 @@ class Mpris2MediaPlayer(dbus.service.Object):
             Sets the current track position in microseconds.
         """
         if track_id == self.properties[PLAYER_INTERFACE]['read_only']['Metadata']['mpris:trackid']:
-            self._sendcommand(["seek", position / 10**6, 2])
+            self._sendcommand(["seek", position / 10**6, 'absolute' if self.mpv else 2])
 
     @dbus.service.method(PLAYER_INTERFACE, in_signature='s')
     def OpenUri(self, uri):


### PR DESCRIPTION
When using an MPRIS-compatible playback widget under GNOME, the
following error appears as the user sets absolute track position:

```
  [ipc_0] Command seek: argument 2 has incompatible type.
```

As it turns out, mpv v0.24.0 expects seek mode argument to be a string.