### PR TITLE
Allow da/dv with unsorted items (fix #554)

### DIFF
--- a/mps_youtube/commands/download.py
+++ b/mps_youtube/commands/download.py
@@ -124,7 +124,7 @@ def download(dltype, num):
     g.content = content.generate_songlist_display()
 
 
-@command(r'(da|dv)\s+(?<![-\d\[\]])(\d+-\d+|-\d+|\d+-|\d+)(?:\[(\d+)\])?(?![-\d\[\]])')
+@command(r'(da|dv)\s+((?:\d+\s\d+|-\d+|\d+-|\d+,)(?:[\d\s,-]*))')
 def down_many(dltype, choice, subdir=None):
     """ Download multiple items. """
     choice = util.parse_multi(choice)


### PR DESCRIPTION
Fix the regexp for the da/dv commands to download multiple items,
allowing items list to have any number of digits (i.e. what we
initially called "unsorted" items in issue #554).

Fix issue #554 and the regression contained in the solution proposed
in commit 11765660293f356878bc7fb8fbbc5f88582a4d20