### PR TITLE
Fix rm command to correctly remove song from playlist

### DIFF
--- a/mps_youtube/commands/songlist.py
+++ b/mps_youtube/commands/songlist.py
@@ -121,8 +121,10 @@ def songlist_rm_add(action, songrange):
 
         for x in selection:
             g.model.songs.pop(x - 1)
-            if not isinstance(g.content, content.PaginatedContent):
+            try:
                 g.active.songs.pop(g.current_page * util.getxy().max_results + x - 1)
+            except IndexError:
+                pass
 
         g.message = util.F('songs rm') % (len(selection), removed)
 

--- a/mps_youtube/commands/songlist.py
+++ b/mps_youtube/commands/songlist.py
@@ -121,6 +121,8 @@ def songlist_rm_add(action, songrange):
 
         for x in selection:
             g.model.songs.pop(x - 1)
+            if not isinstance(g.content, content.PaginatedContent):
+                g.active.songs.pop(g.current_page * util.getxy().max_results + x - 1)
 
         g.message = util.F('songs rm') % (len(selection), removed)
 


### PR DESCRIPTION
Fix for #694. Changes to playlists are now preserved between page changes. This does not affect search results where changes are still reset if you change page, but I'm not sure if that needs changing.