### PR TITLE
commands: search: fix TypeError when search results contain a channel

### DIFF
--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -427,7 +427,7 @@ def get_track_id_from_json(item):
         for p in field.split('/'):
             if node and isinstance(node, dict):
                 node = node.get(p)
-        if node:
+        if node and isinstance(node, str):
             return node
     return ''
 


### PR DESCRIPTION
When searching for e.g. "Ben Howard" one of the results is a channel and
get_track_id_from_json gets confused:

(Pdb) p get_track_id_from_json(items[9])
{'channelId': 'UC7P46taO0CdI8Gy44P1X2yA', 'kind': 'youtube#channel'}

Make get_track_id_from_json ignore nodes that are obvisouly not track
ids.

Signed-off-by: Paul Fertser <fercerpav@gmail.com>