### PR TITLE
Remember volume across multiple songs

### DIFF
--- a/mps_youtube/commands/play.py
+++ b/mps_youtube/commands/play.py
@@ -35,6 +35,7 @@ def play_pl(name):
 @command(r'(%s{0,3})([-,\d\s\[\]]{1,250})\s*(%s{0,3})$' %
          (RS, RS))
 def play(pre, choice, post=""):
+
     """ Play choice.  Use repeat/random if appears in pre/post. """
     # pylint: disable=R0914
     # too many local variables

--- a/mps_youtube/g.py
+++ b/mps_youtube/g.py
@@ -8,6 +8,7 @@ from . import c, paths
 from .playlist import Playlist
 
 
+volume = None
 transcoder_path = "auto"
 delete_orig = True
 encoders = []

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -311,6 +311,8 @@ def _generate_real_playerargs(song, override, stream, isvideo, softrepeat):
                     util.list_update("--really-quiet", args, remove=True)
                     util.list_update(msglevel, args)
 
+            if g.volume:
+                util.list_update("--volume=" + str(g.volume), args)
             if softrepeat:
                 util.list_update("--loop-file", args)
 
@@ -510,6 +512,8 @@ def _player_status(po_obj, prefix, songlength=0, mpv=False, sockpath=None):
                 elif resp.get('event') == 'property-change' and resp['id'] == 2:
                     volume_level = int(resp['data'])
 
+                if(volume_level and volume_level != g.volume): 
+                    g.volume = volume_level
                 if elapsed_s:
                     line = _make_status_line(elapsed_s, prefix, songlength,
                                             volume=volume_level)
@@ -552,6 +556,9 @@ def _player_status(po_obj, prefix, songlength=0, mpv=False, sockpath=None):
                         except ValueError:
                             continue
 
+
+                    if volume_level and volume_level != g.volume: 
+                        g.volume = volume_level
                     line = _make_status_line(elapsed_s, prefix, songlength,
                                             volume=volume_level)
 

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -290,9 +290,13 @@ def _generate_real_playerargs(song, override, stream, isvideo, softrepeat):
             util.list_update(pd["ignidx"], args)
 
         if "mplayer" in config.PLAYER.get:
+            if g.volume:
+                util.list_update("-volume", args)
+                util.list_update(str(g.volume), args)
             util.list_update("-really-quiet", args, remove=True)
             util.list_update("-noquiet", args)
             util.list_update("-prefer-ipv4", args)
+            
 
         elif "mpv" in config.PLAYER.get:
             if "--ytdl" in g.mpv_options:
@@ -319,6 +323,7 @@ def _generate_real_playerargs(song, override, stream, isvideo, softrepeat):
     elif "vlc" in config.PLAYER.get:
         util.list_update("--play-and-exit", args)
 
+    print("args: " + str(config.PLAYER.get) + str(args) + str(stream['url']))
     return [config.PLAYER.get] + args + [stream['url']]
 
 

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -323,7 +323,6 @@ def _generate_real_playerargs(song, override, stream, isvideo, softrepeat):
     elif "vlc" in config.PLAYER.get:
         util.list_update("--play-and-exit", args)
 
-    print("args: " + str(config.PLAYER.get) + str(args) + str(stream['url']))
     return [config.PLAYER.get] + args + [stream['url']]
 
 


### PR DESCRIPTION
I figured we should find a more consistent way of dealing with volume changes across different songs.
Since we use the volume when we draw the player, I've started storing that in a global variable and
use that value to set the player volume between songs.

I've only tested and implemented this for `mpv` and will implement this for `mplayer` as well. 

## Improvements & Testing
What other things should we do to make this a robust feature? Hopefully without adding much complexity for the user. There are some questions that I would like to raise and discuss.

* Does there need to be setting to turn this feature on or off? 
* Should the volume level persist between sessions?
* Should we expose the variable to the playerargs function?
* Are there generic ways to get the volume of non supported players?

If anyone has some ideas regarding how this functionality should work feel free to raise them as well.