### PR TITLE
Skip unavailable tracks

### DIFF
--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -52,6 +52,11 @@ def play_range(songlist, shuffle=False, repeat=False, override=False):
             g.message = c.y + "Playback halted" + c.w
             raise KeyboardInterrupt
             break
+
+        # skip forbidden, video removed/no longer available, etc. tracks
+        except TypeError:
+            returncode = 1
+
         if config.SET_TITLE.get:
             util.set_window_title("mpsyt")
 


### PR DESCRIPTION
Any tracks that are not available (forbidden, video removed/no longer available) are skipped and the next one in queue (if any) is played.

Fixes #724.