### PR TITLE
Load MP3s from a local directory

### DIFF
--- a/mps_youtube/commands/local_playlist.py
+++ b/mps_youtube/commands/local_playlist.py
@@ -158,7 +158,7 @@ def open_save_view(action, name):
             g.content = content.generate_songlist_display()
 
 
-@command(r'local (open|view) \s*(%s)' % WORD)
+@command(r'local (open|view) \s*([^\s]+)')
 def local_open_view(action, path):
     """ Open or view music from a directory """
     songs = []

--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -246,24 +246,30 @@ def video_info(num):
     elif g.browse_mode == "normal":
         g.content = logo(c.b)
         screen.update()
-        screen.writestatus("Fetching video metadata..")
         item = (g.model[int(num) - 1])
-        streams.get(item)
-        p = util.get_pafy(item)
-        pub = datetime.strptime(str(p.published), "%Y-%m-%d %H:%M:%S")
-        pub = util.utc2local(pub)
-        screen.writestatus("Fetched")
-        out = c.ul + "Video Info" + c.w + "\n\n"
-        out += p.title or ""
-        out += "\n" + (p.description or "") + "\n"
-        out += "\nAuthor     : " + str(p.author)
-        out += "\nPublished  : " + pub.strftime("%c")
-        out += "\nView count : " + str(p.viewcount)
-        out += "\nRating     : " + str(p.rating)[:4]
-        out += "\nLikes      : " + str(p.likes)
-        out += "\nDislikes   : " + str(p.dislikes)
-        out += "\nCategory   : " + str(p.category)
-        out += "\nLink       : " + "https://youtube.com/watch?v=%s" % p.videoid
+        if hasattr(item, 'path'):
+            out = c.ul + "Local Media Info" + c.w + "\n\n"
+            out += item.title
+            out += "\nPath   : " + str(item.path)
+            out += "\nLength : " + str(item.length)
+        else:
+            screen.writestatus("Fetching video metadata..")
+            streams.get(item)
+            p = util.get_pafy(item)
+            pub = datetime.strptime(str(p.published), "%Y-%m-%d %H:%M:%S")
+            pub = util.utc2local(pub)
+            screen.writestatus("Fetched")
+            out = c.ul + "Video Info" + c.w + "\n\n"
+            out += p.title or ""
+            out += "\n" + (p.description or "") + "\n"
+            out += "\nAuthor     : " + str(p.author)
+            out += "\nPublished  : " + pub.strftime("%c")
+            out += "\nView count : " + str(p.viewcount)
+            out += "\nRating     : " + str(p.rating)[:4]
+            out += "\nLikes      : " + str(p.likes)
+            out += "\nDislikes   : " + str(p.dislikes)
+            out += "\nCategory   : " + str(p.category)
+            out += "\nLink       : " + "https://youtube.com/watch?v=%s" % p.videoid
         out += "\n\n%s[%sPress enter to go back%s]%s" % (c.y, c.w, c.y, c.w)
         g.content = out
 
@@ -274,20 +280,23 @@ def stream_info(num):
     if g.browse_mode == "normal":
         g.content = logo(c.b)
         screen.update()
-        screen.writestatus("Fetching stream metadata..")
         item = (g.model[int(num) - 1])
-        streams.get(item)
-        p = util.get_pafy(item)
-        setattr(p, 'ytid', p.videoid)
-        details = player.stream_details(p)[1]
-        screen.writestatus("Fetched")
         out = "\n\n" + c.ul + "Stream Info" + c.w + "\n"
-        out += "\nExtension   : " + details['ext']
-        out += "\nSize        : " + str(details['size'])
-        out += "\nQuality     : " + details['quality']
-        out += "\nRaw bitrate : " + str(details['rawbitrate'])
-        out += "\nMedia type  : " + details['mtype']
-        out += "\nLink        : " + details['url']
+        if hasattr(item, 'path'):
+            out += "\nCannot fetch stream info for local media"
+        else:
+            screen.writestatus("Fetching stream metadata..")
+            streams.get(item)
+            p = util.get_pafy(item)
+            setattr(p, 'ytid', p.videoid)
+            details = player.stream_details(p)[1]
+            screen.writestatus("Fetched")
+            out += "\nExtension   : " + details['ext']
+            out += "\nSize        : " + str(details['size'])
+            out += "\nQuality     : " + details['quality']
+            out += "\nRaw bitrate : " + str(details['rawbitrate'])
+            out += "\nMedia type  : " + details['mtype']
+            out += "\nLink        : " + details['url']
         out += "\n\n%s[%sPress enter to go back%s]%s" % (c.y, c.w, c.y, c.w)
         g.content = out
 

--- a/mps_youtube/commands/songlist.py
+++ b/mps_youtube/commands/songlist.py
@@ -9,7 +9,8 @@ from . import command, PL
 
 
 def paginatesongs(func, page=0, splash=True, dumps=False,
-        length=None, msg=None, failmsg=None, loadmsg=None):
+        length=None, msg=None, failmsg=None, loadmsg=None,
+        local=False):
     """
     A utility function for handling lists of songs, so that
     the pagination and the dump command will work properly.
@@ -68,12 +69,12 @@ def paginatesongs(func, page=0, splash=True, dumps=False,
     g.content = content.generate_songlist_display()
     g.last_opened = ""
     g.message = msg or ''
-    if not songs:
-        g.message = failmsg or g.message
-
     if songs:
-        # preload first result url
-        streams.preload(songs[0], delay=0)
+        if not local:
+            # preload first result url
+            streams.preload(songs[0], delay=0)
+    else:
+        g.message = failmsg or g.message
 
 
 @command(r'pl\s+%s' % PL)

--- a/mps_youtube/content.py
+++ b/mps_youtube/content.py
@@ -80,7 +80,12 @@ def generate_songlist_display(song=False, zeromsg=None):
         return logo(c.g) + "\n\n"
     g.rprompt = page_msg(g.current_page)
 
-    have_meta = all(x.ytid in g.meta for x in g.model)
+    local_media = "LocalMedia" == g.model[0].__class__.__name__
+
+    if local_media:
+        have_meta = False
+    else:
+        have_meta = all(x.ytid in g.meta for x in g.model)
 
     user_columns = _get_user_columns() if have_meta else []
     maxlength = max(x.length for x in g.model)
@@ -115,7 +120,10 @@ def generate_songlist_display(song=False, zeromsg=None):
         details['title'] = uea_pad(columns[1]['size'], otitle)
         cat = details.get('category') or '-'
         details['category'] = pafy.get_categoryname(cat)
-        details['ytid'] = x.ytid
+        if local_media:
+            details['path'] = x.path
+        else:
+            details['ytid'] = x.ytid
         data = []
 
         for z in columns:

--- a/mps_youtube/history.py
+++ b/mps_youtube/history.py
@@ -36,8 +36,12 @@ def save():
         hf.write('#EXTM3U\n\n')
         if 'history' in g.userhist:
             for song in g.userhist['history'].songs:
+                local_media = local_media = "LocalMedia" == g.model[0].__class__.__name__
                 hf.write('#EXTINF:%d,%s\n' % (song.length, song.title))
-                hf.write('https://www.youtube.com/watch?v=%s\n' % song.ytid)
+                if local_media:
+                    hf.write(song.path)
+                else:
+                    hf.write('https://www.youtube.com/watch?v=%s\n' % song.ytid)
 
     dbg(c.r + "History saved\n---" + c.w)
 

--- a/mps_youtube/playlist.py
+++ b/mps_youtube/playlist.py
@@ -35,9 +35,18 @@ class Playlist:
 class Video:
 
     """ Class to represent a YouTube video. """
-    description = ""
     def __init__(self, ytid, title, length):
         """ class members. """
         self.ytid = ytid
+        self.title = title
+        self.length = int(length)
+
+
+class LocalMedia:
+
+    """ Class to represent a local media file. """
+    def __init__(self, path, title, length):
+        """ class members. """
+        self.path = path
         self.title = title
         self.length = int(length)

--- a/mps_youtube/playlists.py
+++ b/mps_youtube/playlists.py
@@ -69,7 +69,7 @@ def read_m3u(m3u):
                 if line.startswith('#EXTINF:') and not expect_ytid:
                     duration, title = line.replace('#EXTINF:', '').strip().split(',', 1)
                     expect_ytid = True
-                elif not line.startswith('\n') and not line.startswith('#') and expect_ytid:
+                elif line.startswith('http') and not line.startswith('#') and expect_ytid:
                     ytid = extract_video_id(line).strip()
                     songs.append(Video(ytid, title, int(duration)))
                     expect_ytid = False

--- a/mps_youtube/streams.py
+++ b/mps_youtube/streams.py
@@ -165,7 +165,8 @@ def preload(song, delay=2, override=False):
 
 def _preload(song, delay, override):
     """  Get streams (runs in separate thread). """
-    if g.preload_disabled:
+    local_media = "LocalMedia" == g.model[0].__class__.__name__
+    if g.preload_disabled or local_media:
         return
 
     ytid = song.ytid


### PR DESCRIPTION
This is still not in any state of being merged. It is just a rough implementation. I wanted some general feedback, if this is the right way to do it.

At the moment, it will look only for MP3s in a directory since MP3 track duration can be known using [mutagen](https://github.com/quodlibet/mutagen) but not for other extensions. We could use FFprobe to detect it for all possible media extensions but it won't be a pythonic solution anymore.

To test this out:
```
pip install mutagen
```

```
./mpsyt local open /path/to/mp3/music
./mpsyt local view /path/to/mp3/music
```
Expect some bugs and I've only tested this with mpv-player at the moment.

Also, the regex should be changed to be more restrictive (it works for any argument at the moment) and it may sometimes say that the directory does not exist when using relative paths.