### PR TITLE
Show proper metadata including album and artist whenever possible

### DIFF
--- a/mps_youtube/mpris.py
+++ b/mps_youtube/mpris.py
@@ -302,7 +302,7 @@ class Mpris2MediaPlayer(dbus.service.Object):
                 'mpris:length' : dbus.Int64(length * 10**6, variant_level=1),
                 'mpris:artUrl' : dbus.String(arturl, variant_level=1),
                 'xesam:title' : dbus.String(title, variant_level=1),
-                'xesam:artist' : dbus.Array(artist),
+                'xesam:artist' : dbus.Array(artist, 's', 1),
                 'xesam:album' : dbus.String(album, variant_level=1) }
 
             if newval != oldval:

--- a/mps_youtube/mpris.py
+++ b/mps_youtube/mpris.py
@@ -291,7 +291,7 @@ class Mpris2MediaPlayer(dbus.service.Object):
                 self.Seeked(newval)
 
         elif name == 'metadata' and val:
-            trackid, title, length, arturl = val
+            trackid, title, length, arturl, artist, album = val
             # sanitize ytid - it uses '-_' which are not valid in dbus paths
             trackid = re.sub('[^a-zA-Z0-9]', '', trackid)
 
@@ -301,7 +301,9 @@ class Mpris2MediaPlayer(dbus.service.Object):
                     '/CurrentPlaylist/ytid/' + trackid, variant_level=1),
                 'mpris:length' : dbus.Int64(length * 10**6, variant_level=1),
                 'mpris:artUrl' : dbus.String(arturl, variant_level=1),
-                'xesam:title' : dbus.String(title, variant_level=1) }
+                'xesam:title' : dbus.String(title, variant_level=1),
+                'xesam:artist' : dbus.Array(artist),
+                'xesam:album' : dbus.String(album, variant_level=1) }
 
             if newval != oldval:
                 self.properties[PLAYER_INTERFACE]['read_only']['Metadata'] = newval

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -635,6 +635,7 @@ def _make_status_line(elapsed_s, prefix, songlength=0, volume=None):
     return prefix + status_line + vol_suffix
 
 def _get_metadata(song_title) :
+    ''' Get metadata from a song title '''
     t = re.sub("[\(\[].*?[\)\]]", "", song_title.lower())
     t = t.split('-')
 
@@ -662,6 +663,7 @@ def _get_metadata(song_title) :
     return metadata
 
 def _get_metadata_from_lastfm(artist, track) :
+    ''' Try to get metadata with a given artist and track '''
     url = 'http://ws.audioscrobbler.com/2.0/?method=track.getInfo&api_key=12dec50313f885d407cf8132697b8712&'
     url += urllib.parse.urlencode({"artist" :  artist}) + '&'
     url += urllib.parse.urlencode({"track" :  track}) + '&'

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -11,7 +11,6 @@ import math
 import time
 import shlex
 from urllib.error import HTTPError, URLError
-import urllib
 
 from . import g, screen, c, streams, history, content, paths, config, util
 
@@ -375,8 +374,6 @@ def _get_input_file():
 def _launch_player(song, songdata, cmd):
     """ Launch player application. """
 
-    #song.title
-
     util.dbg("playing %s", song.title)
     util.dbg("calling %s", " ".join(cmd))
 
@@ -384,15 +381,15 @@ def _launch_player(song, songdata, cmd):
     # not supported by encoding
     cmd = [util.xenc(i) for i in cmd]
 
-    metadata = _get_metadata(song.title)
+    metadata = util._get_metadata(song.title)
 
     if metadata == None :
         arturl = "https://i.ytimg.com/vi/%s/default.jpg" % song.ytid
         metadata = (song.ytid, song.title, song.length, arturl, [''], '')
     else :
         arturl = metadata['album_art_url']
-        temp = (song.ytid, metadata['track_title'], song.length, arturl, [metadata['artist']], metadata['album'])
-        metadata = temp
+        metadata = (song.ytid, metadata['track_title'], song.length, arturl, [metadata['artist']], metadata['album'])
+
     input_file = None
     if ("mplayer" in config.PLAYER.get) or ("mpv" in config.PLAYER.get):
         input_file = _get_input_file()
@@ -633,56 +630,3 @@ def _make_status_line(elapsed_s, prefix, songlength=0, volume=None):
     status_line += " [%s]" % ("=" * (progress - 1) +
                               ">").ljust(prog_bar_size, ' ')
     return prefix + status_line + vol_suffix
-
-def _get_metadata(song_title) :
-    ''' Get metadata from a song title '''
-    t = re.sub("[\(\[].*?[\)\]]", "", song_title.lower())
-    t = t.split('-')
-
-    if len(t) != 2 : #If len is not 2, no way of properly knowing title for sure
-        t = t[0]
-        t = t.split(':')
-        if len(t) != 2 :  #Ugly, but to be safe in case all these chars exist, Will improve
-            t = t[0]
-            t = t.split('|')
-            if len(t) != 2 :
-                return None
-
-    t[0] = re.sub("(ft |ft.|feat |feat.).*.", "", t[0])
-    t[1] = re.sub("(ft |ft.|feat |feat.).*.", "", t[1])
-
-    t[0] = t[0].strip()
-    t[1] = t[1].strip()
-
-    metadata = _get_metadata_from_lastfm(t[0], t[1])
-
-    if metadata != None :
-        return metadata
-
-    metadata = _get_metadata_from_lastfm(t[1], t[0])
-    return metadata
-
-def _get_metadata_from_lastfm(artist, track) :
-    ''' Try to get metadata with a given artist and track '''
-    url = 'http://ws.audioscrobbler.com/2.0/?method=track.getInfo&api_key=12dec50313f885d407cf8132697b8712&'
-    url += urllib.parse.urlencode({"artist" :  artist}) + '&'
-    url += urllib.parse.urlencode({"track" :  track}) + '&'
-    url += '&format=json'
-
-    resp = urllib.request.urlopen(url)
-
-    metadata = dict()
-
-    data = json.loads(resp.read())
-
-    if 'track' != list(data.keys())[0] :
-        return None
-    try :
-        metadata['track_title'] = data['track']['name']
-        metadata['artist'] = data['track']['artist']['name']
-        metadata['album'] = data['track']['album']['title']
-        metadata['album_art_url'] = data['track']['album']['image'][-1]['#text']
-    except :
-        return None
-
-    return metadata


### PR DESCRIPTION
Now fixes metadata when playing songs. This could be extended to fixing metadata (track title, album, artist, album art) when downloading songs. But that would add mutagen as a dependency; so I was not sure of implementing that (That could be a future PR). Switches to old method of displaying thumbnails if no proper metadata was found. Please see attached image. Fixes #209 and #495 .

![image](https://user-images.githubusercontent.com/31964688/33949486-c08e3df0-e04f-11e7-870d-a25615e81dce.png)
