### PR TITLE
Added fixing of metadata when downloading m4a audio files.

### DIFF
--- a/mps_youtube/commands/download.py
+++ b/mps_youtube/commands/download.py
@@ -382,7 +382,7 @@ def _download(song, filename, url=None, audio=False, allow_transcode=True):
     ext = filename.split(".")[-1]
     valid_ext = ext in active_encoder['valid'].split(",")
 
-    if audio and filename.split('.')[-1] == 'm4a':
+    if audio and filename.split('.')[-1] == 'm4a' and MUTAGEN_PRESENT:
         remux_audio(filename, song.title)
 
     if config.ENCODER.get != 0 and valid_ext and allow_transcode:


### PR DESCRIPTION
This PR is in continuation with #739 . This PR adds mutagen as an optional dependency. If mutagen is found and the file currently downloading is a m4a audio file, then it tries to fix the metadata.