### PR TITLE
Player_status: minutes are now correctly displayed

### DIFF
--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -607,7 +607,7 @@ def _make_status_line(elapsed_s, prefix, songlength=0, volume=None):
         display_m = display_s // 60
         display_s %= 60
 
-        if display_m >= 100:
+        if display_m >= 60:
             display_h = display_m // 60
             display_m %= 60
 


### PR DESCRIPTION
Code is kind of incoherent, minutes can go above 60 and then they are correctly displayed when above 100.