### PR TITLE
Add pip3 --user flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,19 +92,19 @@ Linux
 ~~~~~
 Using `pip <http://www.pip-installer.org>`_::
 
-    [sudo] pip3 install mps-youtube
+    $ pip3 install --user mps-youtube
 
 To install the experimental development version and try the latest features:
 
-    [sudo] pip3 install -U git+https://github.com/mps-youtube/mps-youtube.git
+    $ pip3 install --user -U git+https://github.com/mps-youtube/mps-youtube.git
 
 Installing youtube-dl is highly recommended::
 
-    [sudo] pip3 install youtube-dl
+    $ pip3 install --user youtube-dl
 
 For mpris2 support, install the python bindings for dbus and gobject::
 
-    [sudo] pip3 install dbus-python pygobject
+    $ pip3 install --user dbus-python pygobject
 
 Ubuntu
 ~~~~~~


### PR DESCRIPTION
To avoid warning:

> WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
