### PR TITLE
Fix 'mkp' when used with a text file

### DIFF
--- a/mps_youtube/commands/generate_playlist.py
+++ b/mps_youtube/commands/generate_playlist.py
@@ -55,7 +55,11 @@ def create_playlist(queries, title=None):
     Create playlist with a random name, get the first
     match for each title in queries and append it to the playlist
     """
-    plname = title.replace(" ", "-") or random_plname()
+    plname = None
+    if (title is not None): 
+        plname=title.replace(" ", "-") 
+    else: 
+        plname=random_plname()
     if not g.userpl.get(plname):
         g.userpl[plname] = Playlist(plname)
     for query in queries:


### PR DESCRIPTION
If we call .replace on `title` and `title` is None from the get-go, as it is defined as such in the parameter list, then the command `mkp` inside the program crashes the program. `help search` in the program never suggests to have a title for the playlist as argument for `mkp`. From where `create_playlist` function is called (inside `generate_playlist` function), it never receives an argument for `title`, as such `title` remains None and gets called with .replace (and crashes program). Therefore, `mkp list.txt` for example will always crash the program when trying to make a playlist based off a text file.

This code could be made more shorter, but I don't write Python much. It is also my first ever pull request so bear with my beginner tendencies.