### PR TITLE
Use maximum available resolution for thumbnail

### DIFF
--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -138,11 +138,28 @@ class BasePlayer:
         """ Launch player application. """
         pass
 
+    def _getbestthumb(self):
+        part_url = "http://i.ytimg.com/vi/%s/" % self.song.ytid
+        # Thumbnail resolution sorted in descending order
+        thumbs = ("maxresdefault.jpg",
+                  "sddefault.jpg",
+                  "hqdefault.jpg",
+                  "mqdefault.jpg",
+                  "default.jpg")
+        for thumb in thumbs:
+            url = part_url + thumb
+            # TODO:
+            # Replace this with `pafy.backend_shared.BasePafy._content_available()`
+            # and cleanup `util._content_available()` once mps-youtube/pafy#211 has merged
+            # We could also try replace this function with `Pafy.getbestthumb()`.
+            if util._content_available(url):
+                return url
+
     def send_metadata_mpris(self):
         metadata = util._get_metadata(self.song.title)
 
         if metadata is None:
-            arturl = "https://i.ytimg.com/vi/%s/default.jpg" % self.song.ytid
+            arturl = self._getbestthumb()
             metadata = (self.song.ytid, self.song.title, self.song.length,
                         arturl, [''], '')
         else:

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -84,6 +84,15 @@ def has_exefile(filename):
     return False
 
 
+def _content_available(url):
+    try:
+        response = urllib.request.urlopen(url)
+    except urllib.request.HTTPError:
+        return False
+    else:
+        return response.getcode() < 300
+
+
 def dbg(*args):
     """Emit a debug message."""
     # Uses xenc to deal with UnicodeEncodeError when writing to terminal


### PR DESCRIPTION
This PR improves thumbnail quality in metadata when using mpris API (instead of always falling back to `default.jpg`). One drawback is that this makes things a little slower (checking if URLs responds with 200 or not). Not sure if it is worth it though, let's decide!

Cross reference: mps-youtube/pafy#211