### PR TITLE
Fix mpris crash on `KeyboardInterrupt`

### DIFF
--- a/mps_youtube/mpris.py
+++ b/mps_youtube/mpris.py
@@ -90,8 +90,8 @@ class Mpris2Controller:
         """
             Notifies interfaces that player connection changed
         """
-        try:
-            while True:
+        while True:
+            try:
                 data = conn.recv()
                 if isinstance(data, tuple):
                     name, val = data
@@ -103,8 +103,10 @@ class Mpris2Controller:
                         self.mpris.bindfifo(val, mpv=True)
                     else:
                         self.mpris.setproperty(name, val)
-        except IOError:
-            pass
+            except IOError:
+                break
+            except KeyboardInterrupt:
+                pass
 
     def _acquire_bus(self):
         """


### PR DESCRIPTION
mpris2 controller crashes any time someone issues a `KeyboardInterrupt` and does not work anymore for current mpsyt instance.
```
Process Process-1: 160k; 3 Mb; 00:01:10 [29%]  [===============================>                                                                            ] vol: 100%   
Stopping...                          
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/local/lib/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/home/ritiek/Downloads/mps-youtube/mps_youtube/mpris.py", line 559, in main
    mprisctl.run(connection)
  File "/home/ritiek/Downloads/mps-youtube/mps_youtube/mpris.py", line 87, in run
    self.listenstatus(connection)
  File "/home/ritiek/Downloads/mps-youtube/mps_youtube/mpris.py", line 96, in listenstatus
    data = conn.recv()
  File "/usr/local/lib/python3.6/multiprocessing/connection.py", line 250, in recv
    buf = self._recv_bytes()
  File "/usr/local/lib/python3.6/multiprocessing/connection.py", line 407, in _recv_bytes
    buf = self._recv(4)
  File "/usr/local/lib/python3.6/multiprocessing/connection.py", line 379, in _recv
    chunk = read(handle, remaining)
KeyboardInterrupt
```

This PR handles `KeyboardInterrupt` gracefully.