### PR TITLE
Fix #847 => Player crash when video is unavailable or forbidden

### DIFF
--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -18,7 +18,6 @@ from .commands import lastfm
 mswin = os.name == "nt"
 not_utf8_environment = mswin or "UTF-8" not in sys.stdout.encoding
 
-
 class BasePlayer:
     _playbackStatus = "Paused"
     _last_displayed_line = None
@@ -84,6 +83,7 @@ class BasePlayer:
 
             # skip forbidden, video removed/no longer available, etc. tracks
             except TypeError:
+                self.song_no += 1
                 pass
 
             if config.SET_TITLE.get:
@@ -335,6 +335,9 @@ def stream_details(song, failcount=0, override=False, softrepeat=False):
         g.message = util.F('track unresolved')
         util.dbg("----valueerror in stream_details call to streams.get")
         return
+
+    if failcount == g.max_retries:
+        raise TypeError()
 
     try:
         video = ((config.SHOW_VIDEO.get and override != "audio") or


### PR DESCRIPTION
Did not report the original issue but having the same problem very often.
This fix seems legit to me, did little testing and it worked, felt like some part of the code were missing according to the comment.
