### PR TITLE
Filter out html code from pafy.util.GdataError

### DIFF
--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -107,7 +107,6 @@ def fetch_comments(item):
     try:
         jsdata = pafy.call_gdata('commentThreads', qs)
     except pafy.util.GdataError as e:
-        print(" " * util.getxy()[0] + "\r") # blank the li
         raise pafy.util.GdataError(str(e).replace(" identified by the <code><a href=\"/youtube/v3/docs/commentThreads/list#videoId\">videoId</a></code> parameter", ""))
     coms = [x.get('snippet', {}) for x in jsdata.get('items', [])]
 

--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -108,8 +108,7 @@ def fetch_comments(item):
         jsdata = pafy.call_gdata('commentThreads', qs)
     except pafy.util.GdataError as e:
         print(" " * util.getxy()[0] + "\r") # blank the li
-        print(str(e).replace(" identified by the <code><a href=\"/youtube/v3/docs/commentThreads/list#videoId\">videoId</a></code> parameter", ""))
-        return None
+        raise pafy.util.GdataError(str(e).replace(" identified by the <code><a href=\"/youtube/v3/docs/commentThreads/list#videoId\">videoId</a></code> parameter", ""))
     coms = [x.get('snippet', {}) for x in jsdata.get('items', [])]
 
     # skip blanks

--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -21,7 +21,6 @@ except ImportError:
     has_readline = False
 
 import pafy
-
 from .. import g, c, __version__, content, screen, cache
 from .. import streams, history, config, util
 from ..helptext import get_help
@@ -104,8 +103,13 @@ def fetch_comments(item):
           'maxResults': 50,
           'part': 'snippet'}
 
-    jsdata = pafy.call_gdata('commentThreads', qs)
-
+    jsdata = None
+    try:
+        jsdata = pafy.call_gdata('commentThreads', qs)
+    except pafy.util.GdataError as e:
+        print(" " * util.getxy()[0] + "\r") # blank the li
+        print(str(e).replace(" identified by the <code><a href=\"/youtube/v3/docs/commentThreads/list#videoId\">videoId</a></code> parameter", ""))
+        return None
     coms = [x.get('snippet', {}) for x in jsdata.get('items', [])]
 
     # skip blanks


### PR DESCRIPTION
References #820

pafys GDataError uses error messages from returned
api calls.

If comments were called on a video with comments disabled;
the error returned would be somewhat non-sensical to an
end user.

The error message contained some superflous information including
the html code pasted below.
`<code><a
href=\"/youtube/v3/docs/commentThreads/list#videoId\">videoId</a></code>`

This commit removes the superflous information and
has the function return a simple `Youtube error 403: The video has
comments disabled`