### PR TITLE
Better @command definition that can register tab-completion strings

### DIFF
--- a/mps_youtube/commands/__init__.py
+++ b/mps_youtube/commands/__init__.py
@@ -13,14 +13,13 @@ PL = r'\S*?((?:RD|PL|LL)[-_0-9a-zA-Z]+)\s*'
 
 ## @command decorator
 ##
-## The @command decorator takes two arguments, one is a regex that
-## is used to match the text command. All following arguments 
-## are strings that match the regex that is going to be added to
-## tab completion. 
+## The @command decorator takes a single regex followed by one or more
+## strings that corresponds to command names that will be added to
+## the tab completion.
 ##
 ## If your command has short-forms, only register the longer
 ## forms.
-## If you use several functions for the same command but different
+## If you use several functions and regexes for the same command but different
 ## arguments, append the completion string on EACH function, not only
 ## the first time you register it.
 def command(regex, *commands):

--- a/mps_youtube/commands/__init__.py
+++ b/mps_youtube/commands/__init__.py
@@ -11,7 +11,18 @@ WORD = r'[^\W\d][-\w\s]{,100}'
 RS = r'(?:(?:repeat|shuffle|-[avfw])\s*)'
 PL = r'\S*?((?:RD|PL|LL)[-_0-9a-zA-Z]+)\s*'
 
-
+## @command decorator
+##
+## The @command decorator takes two arguments, one is a regex that
+## is used to match the text command. All following arguments 
+## are strings that match the regex that is going to be added to
+## tab completion. 
+##
+## If your command has short-forms, only register the longer
+## forms.
+## If you use several functions for the same command but different
+## arguments, append the completion string on EACH function, not only
+## the first time you register it.
 def command(regex, *commands):
     """ Decorator to register an mps-youtube command. """
     for command in commands:

--- a/mps_youtube/commands/__init__.py
+++ b/mps_youtube/commands/__init__.py
@@ -2,7 +2,7 @@ import collections
 import re
 
 from .. import g
-
+from ..main import completer
 
 Command = collections.namedtuple('Command', 'regex category usage function')
 
@@ -12,9 +12,10 @@ RS = r'(?:(?:repeat|shuffle|-[avfw])\s*)'
 PL = r'\S*?((?:RD|PL|LL)[-_0-9a-zA-Z]+)\s*'
 
 
-def command(regex):
+def command(regex, *commands):
     """ Decorator to register an mps-youtube command. """
-
+    for command in commands:
+        completer.add_cmd(command)
     def decorator(function):
         cmd = Command(re.compile(regex), None, None, function)
         g.commands.append(cmd)

--- a/mps_youtube/commands/album_search.py
+++ b/mps_youtube/commands/album_search.py
@@ -206,7 +206,7 @@ def _get_mb_album(albumname, **kwa):
     return dict(artist=artist, title=title, aid=aid)
 
 
-@command(r'album\s*(.{0,500})')
+@command(r'album\s*(.{0,500})', 'album')
 def search_album(term):
     """Search for albums. """
     # pylint: disable=R0914,R0912

--- a/mps_youtube/commands/config.py
+++ b/mps_youtube/commands/config.py
@@ -2,7 +2,7 @@ from .. import g, c, config, util
 from . import command
 
 
-@command(r'set|showconfig')
+@command(r'set|showconfig', 'set', 'showconfig')
 def showconfig():
     """ Dump config data. """
     width = util.getxy().width
@@ -89,7 +89,7 @@ def setconfig(key, val, is_temp=False):
     g.message = message
 
 
-@command(r'encoders?')
+@command(r'encoders?', 'encoder')
 def show_encs():
     """ Display available encoding presets. """
     out = "%sEncoding profiles:%s\n\n" % (c.ul, c.w)

--- a/mps_youtube/commands/download.py
+++ b/mps_youtube/commands/download.py
@@ -14,7 +14,7 @@ from .search import yt_url, user_pls
 from .songlist import dump, plist
 
 
-@command(r'(dv|da|d|dl|download)\s*(\d{1,4})')
+@command(r'(dv|da|d|dl|download)\s*(\d{1,4})', 'da', 'dv', 'd', 'dl', 'download')
 def download(dltype, num):
     """ Download a track or playlist by menu item number. """
     # This function needs refactoring!
@@ -124,7 +124,7 @@ def download(dltype, num):
     g.content = content.generate_songlist_display()
 
 
-@command(r'(da|dv)\s+((?:\d+\s\d+|-\d+|\d+-|\d+,)(?:[\d\s,-]*))')
+@command(r'(da|dv)\s+((?:\d+\s\d+|-\d+|\d+-|\d+,)(?:[\d\s,-]*))', 'da', 'dv')
 def down_many(dltype, choice, subdir=None):
     """ Download multiple items. """
     choice = util.parse_multi(choice)
@@ -188,7 +188,7 @@ def down_many(dltype, choice, subdir=None):
         g.content = content.generate_songlist_display()
 
 
-@command(r'(da|dv)pl\s+%s' % PL)
+@command(r'(da|dv)pl\s+%s' % PL, 'dapl', 'dvpl')
 def down_plist(dltype, parturl):
     """ Download YouTube playlist. """
 
@@ -202,7 +202,7 @@ def down_plist(dltype, parturl):
     g.message = msg
 
 
-@command(r'(da|dv)upl\s+(.*)')
+@command(r'(da|dv)upl\s+(.*)', 'daupl', 'dvupl')
 def down_user_pls(dltype, user):
     """ Download all user playlists. """
     user_pls(user)
@@ -537,7 +537,7 @@ def get_dl_data(song, mediatype="any"):
     return dldata, p
 
 
-@command(r'dlurl\s(.*[-_a-zA-Z0-9]{11}.*)')
+@command(r'dlurl\s(.*[-_a-zA-Z0-9]{11}.*)', 'dlurl')
 def dl_url(url):
     """ Open and prompt for download of youtube video url. """
     g.browse_mode = "normal"
@@ -550,7 +550,7 @@ def dl_url(url):
         sys.exit()
 
 
-@command(r'daurl\s(.*[-_a-zA-Z0-9]{11}.*)')
+@command(r'daurl\s(.*[-_a-zA-Z0-9]{11}.*)', 'daurl')
 def da_url(url):
     """ Open and prompt for download of youtube best audio from url. """
     g.browse_mode = "normal"

--- a/mps_youtube/commands/generate_playlist.py
+++ b/mps_youtube/commands/generate_playlist.py
@@ -11,7 +11,7 @@ from ..playlist import Playlist
 from . import command, search, album_search
 
 
-@command(r'mkp\s*(.{1,100})')
+@command(r'mkp\s*(.{1,100})', 'mkp')
 def generate_playlist(sourcefile):
     """Generate a playlist from video titles in sourcefile"""
 

--- a/mps_youtube/commands/lastfm.py
+++ b/mps_youtube/commands/lastfm.py
@@ -10,7 +10,7 @@ except ImportError:
 from .. import g, util, config
 from . import command
 
-@command(r'lastfm_connect')
+@command(r'lastfm_connect', 'lastfm_connect')
 def init_network(verbose=True):
     """ Initialize the global pylast network variable """
     if not has_pylast :

--- a/mps_youtube/commands/local_playlist.py
+++ b/mps_youtube/commands/local_playlist.py
@@ -6,7 +6,7 @@ from . import command, WORD
 from .songlist import paginatesongs, songlist_rm_add
 
 
-@command(r'rmp\s*(\d+|%s)' % WORD)
+@command(r'rmp\s*(\d+|%s)' % WORD, 'rmp')
 def playlist_remove(name):
     """ Delete a saved playlist by name - or purge working playlist if *all."""
     if name.isdigit() or g.userpl.get(name):
@@ -25,7 +25,7 @@ def playlist_remove(name):
         g.content = content.playlists_display()
 
 
-@command(r'add\s*(-?\d[-,\d\s]{1,250})(%s)' % WORD)
+@command(r'add\s*(-?\d[-,\d\s]{1,250})(%s)' % WORD, 'add')
 def playlist_add(nums, playlist):
     """ Add selected song nums to saved playlist. """
     nums = util.parse_multi(nums)
@@ -46,14 +46,14 @@ def playlist_add(nums, playlist):
     g.content = content.generate_songlist_display()
 
 
-@command(r'mv\s*(\d{1,3})\s*(%s)' % WORD)
+@command(r'mv\s*(\d{1,3})\s*(%s)' % WORD, 'mv')
 def playlist_rename_idx(_id, name):
     """ Rename a playlist by ID. """
     _id = int(_id) - 1
     playlist_rename(sorted(g.userpl)[_id] + " " + name)
 
 
-@command(r'mv\s*(%s\s+%s)' % (WORD, WORD))
+@command(r'mv\s*(%s\s+%s)' % (WORD, WORD), 'mv')
 def playlist_rename(playlists_):
     """ Rename a playlist using mv command. """
     # Deal with old playlist names that permitted spaces
@@ -73,7 +73,7 @@ def playlist_rename(playlists_):
     playlists.save()
 
 
-@command(r'(rm|add)\s(?:\*|all)')
+@command(r'(rm|add)\s(?:\*|all)', 'rm', 'add')
 def add_rm_all(action):
     """ Add all displayed songs to current playlist.
 
@@ -90,7 +90,7 @@ def add_rm_all(action):
         songlist_rm_add("add", "-" + str(size))
 
 
-@command(r'save')
+@command(r'save', 'save')
 def save_last():
     """ Save command with no playlist name. """
     if g.last_opened:
@@ -118,7 +118,7 @@ def save_last():
         open_save_view("save", saveas)
 
 
-@command(r'(open|save|view)\s*(%s)' % WORD)
+@command(r'(open|save|view)\s*(%s)' % WORD, 'open', 'save', 'view')
 def open_save_view(action, name):
     """ Open, save or view a playlist by name.  Get closest name match. """
     name = name.replace(" ", "-")
@@ -156,7 +156,7 @@ def open_save_view(action, name):
             g.content = content.generate_songlist_display()
 
 
-@command(r'(open|view)\s*(\d{1,4})')
+@command(r'(open|view)\s*(\d{1,4})', 'open', 'view')
 def open_view_bynum(action, num):
     """ Open or view a saved playlist by number. """
     srt = sorted(g.userpl)
@@ -164,7 +164,7 @@ def open_view_bynum(action, num):
     open_save_view(action, name)
 
 
-@command(r'ls')
+@command(r'ls', 'ls')
 def ls():
     """ List user saved playlists. """
     if not g.userpl:
@@ -177,7 +177,7 @@ def ls():
         g.message = util.F('pl help')
 
 
-@command(r'vp')
+@command(r'vp', 'vp')
 def vp():
     """ View current working playlist. """
 

--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -39,14 +39,14 @@ def clearcache():
     g.message = "cache cleared"
 
 
-@command(r'(?:help|h)(?:\s+([-_a-zA-Z]+))?')
+@command(r'(?:help|h)(?:\s+([-_a-zA-Z]+))?', 'help')
 def show_help(choice):
     """ Print help message. """
 
     g.content = get_help(choice)
 
 
-@command(r'(?:q|quit|exit)')
+@command(r'(?:q|quit|exit)', 'quit', 'exit')
 def quits(showlogo=True):
     """ Exit the program. """
     if has_readline:
@@ -132,7 +132,7 @@ def fetch_comments(item):
     g.content = content.StringContent(commentstext)
 
 
-@command(r'c\s?(\d{1,4})')
+@command(r'c\s?(\d{1,4})', 'c')
 def comments(number):
     """ Receive use request to view comments. """
     if g.browse_mode == "normal":
@@ -144,7 +144,7 @@ def comments(number):
         g.message = "Comments only available for video items"
 
 
-@command(r'x\s*(\d+)')
+@command(r'x\s*(\d+)', 'x')
 def clipcopy_video(num):
     """ Copy video/playlist url to clipboard. """
     if g.browse_mode == "ytpl":
@@ -179,7 +179,7 @@ def clipcopy_video(num):
         g.content = generate_songlist_display()
 
 
-@command(r'X\s*(\d+)')
+@command(r'X\s*(\d+)', 'X')
 def clipcopy_stream(num):
     """ Copy content stream url to clipboard. """
     if g.browse_mode == "normal":
@@ -211,7 +211,7 @@ def clipcopy_stream(num):
         g.content = generate_songlist_display()
 
 
-@command(r'i\s*(\d{1,4})')
+@command(r'i\s*(\d{1,4})', 'i')
 def video_info(num):
     """ Get video information. """
     if g.browse_mode == "ytpl":
@@ -268,7 +268,7 @@ def video_info(num):
         g.content = out
 
 
-@command(r's\s*(\d{1,4})')
+@command(r's\s*(\d{1,4})', 's')
 def stream_info(num):
     """ Get stream information. """
     if g.browse_mode == "normal":
@@ -292,7 +292,7 @@ def stream_info(num):
         g.content = out
 
 
-@command(r'history')
+@command(r'history', 'history')
 def view_history(duplicates=True):
     """ Display the user's play history """
     history = g.userhist.get('history')
@@ -314,13 +314,13 @@ def view_history(duplicates=True):
         g.message = "History empty"
 
 
-@command(r'history recent')
+@command(r'history recent', 'history recent')
 def recent_history():
     """ Display the recent user's played songs """
     view_history(duplicates=False)
 
 
-@command(r'history clear')
+@command(r'history clear', 'history clear')
 def clear_history():
     """ Clears the user's play history """
     g.userhist['history'].songs = []

--- a/mps_youtube/commands/play.py
+++ b/mps_youtube/commands/play.py
@@ -9,7 +9,7 @@ from .songlist import plist
 from .search import yt_url, related
 
 
-@command(r'play\s+(%s|\d+)' % WORD)
+@command(r'play\s+(%s|\d+)' % WORD, 'play')
 def play_pl(name):
     """ Play a playlist by name. """
     if name.isdigit():
@@ -34,7 +34,7 @@ def play_pl(name):
 @command(r'(%s{0,3})([-,\d\s\[\]]{1,250})\s*(%s{0,3})$' %
          (RS, RS))
 def play(pre, choice, post=""):
-
+    print("\r\n\r\nPLAY CALL")
     """ Play choice.  Use repeat/random if appears in pre/post. """
     # pylint: disable=R0914
     # too many local variables
@@ -44,6 +44,7 @@ def play(pre, choice, post=""):
     if isinstance(g.content, content.Content):
         play_call = getattr(g.content, "_play", None)
         if callable(play_call):
+            print("is callable")
             play_call(pre, choice, post)
         return
 
@@ -61,6 +62,7 @@ def play(pre, choice, post=""):
         g.content = g.content or content.generate_songlist_display()
 
     else:
+        print("ELSE")
         shuffle = "shuffle" in pre + post
         repeat = "repeat" in pre + post
         novid = "-a" in pre + post
@@ -101,7 +103,6 @@ def play(pre, choice, post=""):
                             "%s to set a player" % (c.g, c.w)
                 return
             g.PLAYER_OBJ.play(songlist, shuffle, repeat, override)
-
         except KeyboardInterrupt:
             return
         finally:
@@ -123,7 +124,7 @@ def play_all(pre, choice, post=""):
     play(options, "1-" + str(len(g.model)))
 
 
-@command(r'playurl\s(.*[-_a-zA-Z0-9]{11}[^\s]*)(\s-(?:f|a|w))?')
+@command(r'playurl\s(.*[-_a-zA-Z0-9]{11}[^\s]*)(\s-(?:f|a|w))?', 'playurl')
 def play_url(url, override):
     """ Open and play a youtube video url. """
     override = override if override else "_"
@@ -137,7 +138,7 @@ def play_url(url, override):
         sys.exit()
 
 
-@command(r'browserplay\s(\d{1,50})')
+@command(r'browserplay\s(\d{1,50})', 'browserplay')
 def browser_play(number):
     """Open a previously searched result in the browser."""
     if (len(g.model) == 0):

--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -185,7 +185,7 @@ def channelsearch(q_user):
     g.message = "Results for channel search: '%s'" % q_user
 
 
-@command(r'user\s+(.+)')
+@command(r'user\s+(.+)', 'user')
 def usersearch(q_user, identify='forUsername'):
     """ Fetch uploads by a YouTube user. """
 
@@ -249,7 +249,7 @@ def related_search(vitem):
 
 
 # Livestream category search
-@command(r'live\s+(.+)')
+@command(r'live\s+(.+)', 'live')
 def livestream_category_search(term):
     sel_category = g.categories.get(term, None)
 
@@ -286,7 +286,7 @@ def livestream_category_search(term):
 
 
 # Note: [^./] is to prevent overlap with playlist search command
-@command(r'(?:search|\.|/)\s*([^./].{1,500})')
+@command(r'(?:search|\.|/)\s*([^./].{1,500})', 'search')
 def search(term):
     """ Perform search. """
     try:  # TODO make use of unknowns
@@ -317,13 +317,13 @@ def search(term):
     _search(term, query, msg, failmsg)
 
 
-@command(r'u(?:ser)?pl\s(.*)')
+@command(r'u(?:ser)?pl\s(.*)', 'userpl', 'upl')
 def user_pls(user):
     """ Retrieve user playlists. """
     return pl_search(user, is_user=True)
 
 
-@command(r'(?:\.\.|\/\/|pls(?:earch)?\s)\s*(.*)')
+@command(r'(?:\.\.|\/\/|pls(?:earch)?\s)\s*(.*)', 'plsearch')
 def pl_search(term, page=0, splash=True, is_user=False):
     """ Search for YouTube playlists.
 
@@ -546,7 +546,7 @@ def num_repr(num):
     return str(rounded)[0] + "." + str(rounded)[1] + suffix
 
 
-@command(r'u\s?([\d]{1,4})')
+@command(r'u\s?([\d]{1,4})', 'u')
 def user_more(num):
     """ Show more videos from user of vid num. """
     if g.browse_mode != "normal":
@@ -569,7 +569,7 @@ def user_more(num):
     usersearch_id(user, channel_id, '')
 
 
-@command(r'r\s?(\d{1,4})')
+@command(r'r\s?(\d{1,4})', 'r')
 def related(num):
     """ Show videos related to to vid num. """
     if g.browse_mode != "normal":
@@ -583,7 +583,7 @@ def related(num):
     related_search(item)
 
 
-@command(r'mix\s*(\d{1,4})')
+@command(r'mix\s*(\d{1,4})', 'mix')
 def mix(num):
     """ Retrieves the YouTube mix for the selected video. """
     g.content = g.content or content.generate_songlist_display()
@@ -602,7 +602,7 @@ def mix(num):
             g.message = util.F('no mix')
 
 
-@command(r'url\s(.*[-_a-zA-Z0-9]{11}.*)')
+@command(r'url\s(.*[-_a-zA-Z0-9]{11}.*)', 'url')
 def yt_url(url, print_title=0):
     """ Acess videos by urls. """
     url_list = url.split()
@@ -630,7 +630,7 @@ def yt_url(url, print_title=0):
         util.xprint(v.title)
 
 
-@command(r'url_file\s(\S+)')
+@command(r'url_file\s(\S+)', 'url_file')
 def yt_url_file(file_name):
     """ Access a list of urls in a text file """
 

--- a/mps_youtube/commands/songlist.py
+++ b/mps_youtube/commands/songlist.py
@@ -76,7 +76,7 @@ def paginatesongs(func, page=0, splash=True, dumps=False,
         streams.preload(songs[0], delay=0)
 
 
-@command(r'pl\s+%s' % PL)
+@command(r'pl\s+%s' % PL, 'pl')
 def plist(parturl):
     """ Retrieve YouTube playlist. """
 
@@ -96,7 +96,7 @@ def plist(parturl):
     paginatesongs(pl_seg, length=len(ytpl), msg=msg, loadmsg=loadmsg)
 
 
-@command(r'(rm|add)\s*(-?\d[-,\d\s]{,250})')
+@command(r'(rm|add)\s*(-?\d[-,\d\s]{,250})', 'rm', 'add')
 def songlist_rm_add(action, songrange):
     """ Remove or add tracks. works directly on user input. """
     selection = util.parse_multi(songrange)
@@ -131,7 +131,7 @@ def songlist_rm_add(action, songrange):
     g.content = content.generate_songlist_display()
 
 
-@command(r'(mv|sw)\s*(\d{1,4})\s*[\s,]\s*(\d{1,4})')
+@command(r'(mv|sw)\s*(\d{1,4})\s*[\s,]\s*(\d{1,4})', 'mv', 'sw')
 def songlist_mv_sw(action, a, b):
     """ Move a song or swap two songs. """
     i, j = int(a) - 1, int(b) - 1
@@ -187,7 +187,7 @@ def nextprev(np, page=None):
     return good
 
 
-@command(r'(un)?dump')
+@command(r'(un)?dump', 'dump', 'undump')
 def dump(un):
     """ Show entire playlist. """
     func, args = g.last_search_query
@@ -202,7 +202,7 @@ def dump(un):
         g.content = content.generate_songlist_display()
 
 
-@command(r'shuffle')
+@command(r'shuffle', 'shuffle')
 def shuffle_fn():
     """ Shuffle displayed items. """
     random.shuffle(g.model.songs)
@@ -210,7 +210,7 @@ def shuffle_fn():
     g.content = content.generate_songlist_display()
 
 
-@command(r'reverse')
+@command(r'reverse', 'reverse')
 def reverse_songs():
     """ Reverse order of displayed items. """
     g.model.songs = g.model.songs[::-1]
@@ -218,7 +218,7 @@ def reverse_songs():
     g.content = content.generate_songlist_display()
 
 
-@command(r'reverse\s*(\d{1,4})\s*-\s*(\d{1,4})\s*')
+@command(r'reverse\s*(\d{1,4})\s*-\s*(\d{1,4})\s*', 'reverse')
 def reverse_songs_range(lower, upper):
     """ Reverse the songs within a specified range. """
     lower, upper = int(lower), int(upper)
@@ -229,7 +229,7 @@ def reverse_songs_range(lower, upper):
     g.content = content.generate_songlist_display()
     
 
-@command(r'reverse all')
+@command(r'reverse all', 'reverse all')
 def reverse_playlist():
     """ Reverse order of entire loaded playlist. """
     # Prevent crash if no last query

--- a/mps_youtube/commands/spotify_playlist.py
+++ b/mps_youtube/commands/spotify_playlist.py
@@ -158,7 +158,7 @@ def _match_tracks(tracks):
         yield s
 
 
-@command(r'suser\s*(.*[-_a-zA-Z0-9].*)?')
+@command(r'suser\s*(.*[-_a-zA-Z0-9].*)?', 'suser')
 def search_user(term):
     """Search for Spotify user playlists. """
     # pylint: disable=R0914,R0912
@@ -211,7 +211,7 @@ def search_user(term):
 
 
 
-@command(r'splaylist\s*(.*[-_a-zA-Z0-9].*)?')
+@command(r'splaylist\s*(.*[-_a-zA-Z0-9].*)?', 'splaylist')
 def search_playlist(term, spotify=None):
     """Search for Spotify playlist. """
     # pylint: disable=R0914,R0912

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -31,6 +31,7 @@ from . import g, c, commands, screen, history, util
 from . import __version__, playlists, content, listview
 from . import config
 
+completer = None
 try:
     import readline
     readline.set_history_length(2000)

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -89,7 +89,6 @@ class BasePlayer:
             if config.SET_TITLE.get:
                 util.set_window_title("mpsyt")
 
-            print("songlistlen " + str(self.song_no) + ":" + str(len(songlist)))
             if self.song_no == -1:
                 self.song_no = len(songlist) - 1 if repeat else 0
             elif self.song_no == len(self.songlist) and repeat:

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -57,7 +57,7 @@ class BasePlayer:
             hasnext = len(self.songlist) > self.song_no + 1
 
             if hasnext:
-                streams.preload(self.songlist[self.song_no + 1],
+                streams.preload(self.songlist[self.song_no +1],
                                 override=self.override)
 
             if config.SET_TITLE.get:
@@ -73,6 +73,7 @@ class BasePlayer:
                                                          override=self.override,
                                                          softrepeat=self.softrepeat)
                 self._playsong()
+                self.song_no += 1
 
             except KeyboardInterrupt:
                 logging.info("Keyboard Interrupt")
@@ -89,10 +90,10 @@ class BasePlayer:
             if config.SET_TITLE.get:
                 util.set_window_title("mpsyt")
 
+            print("songlistlen " + str(self.song_no) + ":" + str(len(songlist)))
             if self.song_no == -1:
                 self.song_no = len(songlist) - 1 if repeat else 0
-
-            elif self.song_no == len(songlist) and repeat:
+            elif self.song_no == len(self.songlist) and repeat:
                 self.song_no = 0
 
     # To be defined by subclass based on being cmd player or library

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -57,7 +57,7 @@ class BasePlayer:
             hasnext = len(self.songlist) > self.song_no + 1
 
             if hasnext:
-                streams.preload(self.songlist[self.song_no +1],
+                streams.preload(self.songlist[self.song_no + 1],
                                 override=self.override)
 
             if config.SET_TITLE.get:
@@ -73,7 +73,6 @@ class BasePlayer:
                                                          override=self.override,
                                                          softrepeat=self.softrepeat)
                 self._playsong()
-                self.song_no += 1
 
             except KeyboardInterrupt:
                 logging.info("Keyboard Interrupt")

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -554,14 +554,7 @@ def assign_player(player):
 
 class CommandCompleter:
 
-    COMMANDS = ['play', 'set', 'album', 'all', 'playurl', 'browserplay',
-                'showconfig', 'encoders', 'dv', 'da', 'dl', 'd', 'download',
-                'dapl', 'dvpl', 'daupl', 'dvupl', 'daurl', 'dvurl', 'mkp',
-                'lastfm_connect', 'rmp', 'add', 'mv', 'save', 'open', 'view',
-                'ls', 'vp', 'clearcache', 'help', 'exit', 'history',
-                'history recent', 'history clear', 'channels', 'user', 'live',
-                'pls', 'mix', 'url', 'url_file', 'pl', 'rm', 'undump', 'dump',
-                'sw', 'shuffle', 'reverse', 'repeat', 'suser', 'splaylist']
+    COMMANDS = []
 
     def __init__(self):
         from . import config
@@ -573,3 +566,6 @@ class CommandCompleter:
         else:
             results = [x for x in self.COMMANDS if x.startswith(text)] + [None]
         return results[state]
+    def add_cmd(self, val):
+        if(not val in self.COMMANDS):
+            self.COMMANDS.append(val)


### PR DESCRIPTION
This PR moves the list of commands from a static list in `util.py` to an argument
that is passed to the @command function. This way we dont have a separate list of tab completion.

ref: #801 