### PR TITLE
Capture the raised exception for error reporting

### DIFF
--- a/mps_youtube/commands/lastfm.py
+++ b/mps_youtube/commands/lastfm.py
@@ -36,7 +36,7 @@ def init_network(verbose=True):
                                                 password_hash=password)
         if verbose:
             g.message = "Last.fm authentication successful!"
-    except (pylast.WSError, pylast.MalformedResponseError, pylast.NetworkError):
+    except (pylast.WSError, pylast.MalformedResponseError, pylast.NetworkError) as e:
         if verbose:
             g.message = "Last.fm connection error: %s" % (str(e))
 


### PR DESCRIPTION
Capture the raised exception in the variable __e__ on line 39 so that it can be recorded on line 41.

flake8 testing of https://github.com/mps-youtube/mps-youtube on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./mps_youtube/commands/lastfm.py:41:63: F821 undefined name 'e'
            g.message = "Last.fm connection error: %s" % (str(e))
                                                              ^
1     F821 undefined name 'e'
1
```