### PR TITLE
Let lastfm metadata recover on HTTPError

### DIFF
--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -514,14 +514,11 @@ def _get_metadata_from_lastfm(artist, track):
     url += urllib.parse.urlencode({"track":  track}) + '&'
     url += '&format=json'
 
-    resp = urllib.request.urlopen(url)
-
-    metadata = dict()
-
-    # Prior to Python 3.6, json.loads cannot take a bytes object
-    data = json.loads(resp.read().decode('utf-8'))
-
     try:
+        resp = urllib.request.urlopen(url)
+        metadata = dict()
+        # Prior to Python 3.6, json.loads cannot take a bytes object
+        data = json.loads(resp.read().decode('utf-8'))
         metadata['track_title'] = data['track']['name']
         metadata['artist'] = data['track']['artist']['name']
         metadata['album'] = data['track']['album']['title']
@@ -529,6 +526,8 @@ def _get_metadata_from_lastfm(artist, track):
     except KeyError:
         return None
     except IndexError:
+        return None
+    except urllib.error.HTTPError:
         return None
 
     return metadata

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -523,13 +523,9 @@ def _get_metadata_from_lastfm(artist, track):
         metadata['artist'] = data['track']['artist']['name']
         metadata['album'] = data['track']['album']['title']
         metadata['album_art_url'] = data['track']['album']['image'][-1]['#text']
-    except KeyError:
+    except (KeyError, IndexError):
         return None
-    except IndexError:
-        return None
-    except urllib.error.HTTPError:
-        return None
-    except urllib.error.URLError:
+    except (urllib.error.HTTPError, urllib.error.URLError):
         return None
     return metadata
 

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -529,7 +529,8 @@ def _get_metadata_from_lastfm(artist, track):
         return None
     except urllib.error.HTTPError:
         return None
-
+    except urllib.error.URLError:
+        return None
     return metadata
 
 


### PR DESCRIPTION
#864 Gets a `403: Forbidden` when trying to fetch metadata when trying to get metadata based on a video with title `Wildstylez - Encore | Dragonblood EP`. 

This isn't a fix to that problem, because I can't find any references to the error, but regardless I think we should be able to recover from the error and move on without lastfm metadata, so I propose this change where both HTTP (server responds with error) and URL (can not reach the api server) related errors are skipped.