### PR TITLE
Use https and add optout for metadata via last.fm

### DIFF
--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -331,6 +331,7 @@ class _Config:
             ConfigItem("window_size", "",
                 check_fn=check_win_size, require_known_player=True),
             ConfigItem("download_command", ''),
+            ConfigItem("lookup_metadata", True),
             ConfigItem("lastfm_username", ''),
             ConfigItem("lastfm_password", '', check_fn=check_lastfm_password),
             ConfigItem("lastfm_api_key", ''),

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -224,6 +224,7 @@ def helptext():
     {2}set overwrite true|false{1} - overwrite existing files (skip if false)
     {2}set player <player app>{1} - use <player app> for playback
     {2}set playerargs <args>{1} - use specified arguments with player
+    {2}set lookup_metadata true|false{1} - lookup metadata using Last.fm
     {2}set lastfm_username <username>{1} - scrobble to this Last.fm userprofile
     {2}set lastfm_password <password>{1} - Last.fm password (saved in hash form)
     {2}set lastfm_api <key>{1} - API key needed for Last.fm mps-yt authorization

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -479,6 +479,12 @@ def _get_mplayer_version(exename):
 
 
 def _get_metadata(song_title):
+
+    # Circular dependency still??
+    from . import config
+    if(config.LOOKUP_METADATA.get == False):
+        return None
+
     ''' Get metadata from a song title '''
     t = re.sub("[\(\[].*?[\)\]]", "", song_title.lower())
     t = t.split('-')

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -515,7 +515,7 @@ def _get_metadata(song_title):
 
 def _get_metadata_from_lastfm(artist, track):
     ''' Try to get metadata with a given artist and track '''
-    url = 'http://ws.audioscrobbler.com/2.0/?method=track.getInfo&api_key=12dec50313f885d407cf8132697b8712&'
+    url = 'https://ws.audioscrobbler.com/2.0/?method=track.getInfo&api_key=12dec50313f885d407cf8132697b8712&'
     url += urllib.parse.urlencode({"artist":  artist}) + '&'
     url += urllib.parse.urlencode({"track":  track}) + '&'
     url += '&format=json'


### PR DESCRIPTION
As noted in #793, we were using `http` over `https` when looking up metadata, this pr changes it to use https instead.

It also adds yet another setting to disable metadata querying all together for those that have issues with this.

Metadata searching is on by default, but can be disabled by running `set lookup_metadata false`