### PR TITLE
Add Arch Linux install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,12 @@ You can install mps-youtube directly from the official repositories:
 
     [sudo] apt install mps-youtube
 
+Arch Linux
+~~~~~~
+You can install mps-youtube directly from the official repositories:
+
+    [sudo] pacman -S mps-youtube
+
 macOS X
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Install mpv (recommended player) with `Homebrew <http://brew.sh>`_::


### PR DESCRIPTION
Similar to Ubuntu, add terminal command to install from the Arch Linux official repos.