### PR TITLE
[Suggestion] Show QRCode in video information panel

### DIFF
--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -24,7 +24,7 @@ import pafy
 from .. import g, c, __version__, content, screen, cache
 from .. import streams, history, config, util
 from ..helptext import get_help
-from ..content import generate_songlist_display, logo
+from ..content import generate_songlist_display, logo, qrcode_display
 from . import command
 from .songlist import paginatesongs
 
@@ -266,6 +266,10 @@ def video_info(num):
         out += "\nDislikes   : " + str(p.dislikes)
         out += "\nCategory   : " + str(p.category)
         out += "\nLink       : " + "https://youtube.com/watch?v=%s" % p.videoid
+        if config.SHOW_QRCODE.get:
+            out += "\n" + qrcode_display(
+                "https://youtube.com/watch?v=%s" % p.videoid)
+
         out += "\n\n%s[%sPress enter to go back%s]%s" % (c.y, c.w, c.y, c.w)
         g.content = out
 

--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -345,6 +345,7 @@ class _Config:
             ConfigItem("autoplay", False),
             ConfigItem("set_title", True),
             ConfigItem("mpris", not mswin),
+            ConfigItem("show_qrcode", False),
             ]
 
     def __getitem__(self, key):

--- a/mps_youtube/content.py
+++ b/mps_youtube/content.py
@@ -7,6 +7,14 @@ import pafy
 from . import g, c, config
 from .util import getxy, fmt_time, uea_pad, yt_datetime, F
 
+try:
+    import qrcode
+    import io
+    HAS_QRCODE = True
+except ImportError:
+    HAS_QRCODE = False
+
+
 # In the future, this could support more advanced features
 class Content:
     pass
@@ -238,3 +246,14 @@ def playlists_display():
         out += l
 
     return out
+
+
+def qrcode_display(url):
+    if not HAS_QRCODE:
+        return "(Install 'qrcode' to generate them)"
+    qr = qrcode.QRCode()
+    buf = io.StringIO()
+    buf.isatty = lambda: True
+    qr.add_data(url)
+    qr.print_ascii(out=buf)
+    return buf.getvalue()

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -239,6 +239,7 @@ def helptext():
     {2}set video_format <auto|mp4|webm|3gp>{1} - set default music video format
     {2}set api_key <key>{1} - use a different API key for accessing the YouTube Data API
     {2}set set_title true|false{1} - change window title
+    {2}set show_qrcode true|false{1} - show qrcode of the URL in the video information panel
     
     Additionally, {2}set -t{1} may be used to temporarily change a setting without
     saving it to disk


### PR DESCRIPTION
This is just a suggestion of a functionality I use on my private branch. I use NewPipe on my phone, and I often want to keep listening to the same video when I leave my laptop.

This PR shows a QRCode of the video URL in the video information panel (`i [number]`) to make it easier to open it on a mobile device, if the new option `show_qrcode` is enabled and the `qrcode` package is installed.


Suggestions and criticism are welcome!

![screenshot](http://sufi.andreparames.com/qr_screenshot.png)