### PR TITLE
fix crash disabled playback on other websites

### DIFF
--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -330,6 +330,10 @@ def stream_details(song, failcount=0, override=False, softrepeat=False):
             g.message = str(e) + " - " + song.ytid
             return
 
+        elif "Watch this video on YouTube." in str(e):
+            g.message = util.F('cant get track') % (song.title + " " + str(e))
+            return
+        
     except ValueError:
         g.message = util.F('track unresolved')
         util.dbg("----valueerror in stream_details call to streams.get")


### PR DESCRIPTION
fix crash with error "Watch this video on YouTube. Playback on other websites has been disabled by the video owner."

Example: "https://www.youtube.com/watch?v=NTUllANqqds"

also if searched for it ".Shinmai" (appears as stream 1)
The error appears once (no crash).
I guess that's intentional....

EDIT: This is actually an age restricted video... Not all age restricted videos are blocked this way though... Example: https://www.youtube.com/watch?v=3iMw1-m_V6U