### PR TITLE
Fix help text altering the terminal color

### DIFF
--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -306,7 +306,7 @@ def helptext():
 
      - New "reverse" command (kraetzin)
 
-     - New "daurl <url>" command (maricn){2}
+     - New "daurl <url>" command (maricn)
     """.format(c.ul, c.w, c.y))]
 
 


### PR DESCRIPTION
I noticed that "mpsyt -h" changes the terminal text color to yellow even after it exits. The yellow text color persists until any other program resets the text color. I traced the issue to a stray yellow text color flag at the end of the helptext string. I have deleted the flag and the terminal text color is no longer altered when the command is run.

By the way, I just started using mps-youtube  a couple days ago. So first of all, thank you for making this great tool. And secondly, if I'm missing anything in the protocol for contributing please do help me out.