### PR TITLE
Option to turn on and off history recording

### DIFF
--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -48,7 +48,7 @@ def show_help(choice):
 @command(r'(?:q|quit|exit)', 'quit', 'exit')
 def quits(showlogo=True):
     """ Exit the program. """
-    if has_readline:
+    if has_readline and config.INPUT_HISTORY.get:
         readline.write_history_file(g.READLINE_FILE)
         util.dbg("Saved history file")
 
@@ -318,6 +318,11 @@ def view_history(duplicates=True):
     except AttributeError:
         g.content = logo(c.r)
         g.message = "History empty"
+
+
+    if not config.HISTORY.get:
+        g.message += "\t{1}History recording is currently off{0}".format(c.w,c.y)
+
 
 
 @command(r'history recent', 'history recent')

--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -346,6 +346,8 @@ class _Config:
             ConfigItem("set_title", True),
             ConfigItem("mpris", not mswin),
             ConfigItem("show_qrcode", False),
+            ConfigItem("history", True), 
+            ConfigItem("input_history", True)
             ]
 
     def __getitem__(self, key):

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -180,6 +180,7 @@ def helptext():
         {2}history{1} - displays a list of songs contained in history
         {2}history clear{1} - clears the song history
         {2}history recent{1} - displays a list of recent played songs
+        {2}set history on|off{1} - toggles history recording
     """.format(c.ul, c.w, c.y)),
 
         ("invoke", "Invocation Parameters", """
@@ -240,7 +241,9 @@ def helptext():
     {2}set api_key <key>{1} - use a different API key for accessing the YouTube Data API
     {2}set set_title true|false{1} - change window title
     {2}set show_qrcode true|false{1} - show qrcode of the URL in the video information panel
-    
+    {2}set history true|false{1} - record play history
+    {2}set input_history true|false{1} - record command input history
+ 
     Additionally, {2}set -t{1} may be used to temporarily change a setting without
     saving it to disk
     """.format(c.ul, c.w, c.y, '\n{0}set max_results <number>{1} - show <number> re'

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -131,7 +131,9 @@ class BasePlayer:
         screen.writestatus(self.songdata)
 
         self._launch_player()
-        history.add(self.song)
+        
+        if config.HISTORY.get:
+            history.add(self.song)
 
     def _launch_player(self):
         """ Launch player application. """


### PR DESCRIPTION
This commit adds an option not have watch and input history recorded, as requested in issue #930 .

I have created two configuration variables: "history", which decides whether watch history is recorded, and "input_history", which decides whether command input history is recorded. Information about these has been added to the help text. I also added a message that informs the user that history is off if they use the "history" command when history is turned off.

I've been looking through the python code and deciphering the inner-workings of mps-youtube. Hopefully I made the changes correctly, but please do tell if I missed something.