### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
-FROM python:latest
-MAINTAINER Justin Garrison <justinleegarrison@gmail.com>
+FROM python:3-stretch
 
-RUN apt-get update && apt-get install -y mplayer mpv
+LABEL maintainer="Justin Garrison <justinleegarrison@gmail.com>" \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.name="mps-youtube" \
+    org.label-schema.description="Terminal based YouTube player and downloader " \
+    org.label-schema.url="https://github.com/mps-youtube/mps-youtube/wiki" \
+    org.label-schema.vcs-url="https://github.com/mps-youtube/mps-youtube" \
+    org.label-schema.docker.cmd="docker run -v /dev/snd:/dev/snd -it --rm --privileged --name mpsyt mpsyt"
+
+RUN DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y mplayer mpv && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean && apt-get purge
+
 RUN pip install mps-youtube youtube-dl
-RUN apt-get clean && apt-get purge
 
 ENTRYPOINT ["mpsyt"]


### PR DESCRIPTION
1. Drop Maintainer (deprecated)
2. Add layers for better understanding of container build
3. Reduce layer use for easier caching.
4. Fix Dockefile ```FROM``` image to numbered version and OS (3-stretch)