### PR TITLE
Fix README Linux install instruction formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,13 +111,13 @@ For mpris2 support, install the python bindings for dbus and gobject::
 
 Ubuntu
 ~~~~~~
-You can install mps-youtube directly from the official repositories:
+You can install mps-youtube directly from the official repositories::
 
     [sudo] apt install mps-youtube
 
 Arch Linux
 ~~~~~~
-You can install mps-youtube directly from the official repositories:
+You can install mps-youtube directly from the official repositories::
 
     [sudo] pacman -S mps-youtube
 


### PR DESCRIPTION
The Arch Linux and Ubuntu install code in README wasn't formatted the same way as the other install instructions for Mac and pip. This change makes them all look the same.