### PR TITLE
Synchronize playlist prefixes with pafy

### DIFF
--- a/mps_youtube/commands/__init__.py
+++ b/mps_youtube/commands/__init__.py
@@ -9,7 +9,7 @@ Command = collections.namedtuple('Command', 'regex category usage function')
 # input types
 WORD = r'[^\W\d][-\w\s]{,100}'
 RS = r'(?:(?:repeat|shuffle|-[avfw])\s*)'
-PL = r'\S*?((?:RD|PL|LL|OL)[-_0-9a-zA-Z]+)\s*'
+PL = r'\S*?((?:RD|PL|LL|UU|FL|OL)[-_0-9a-zA-Z]+)\s*'
 
 ## @command decorator
 ##


### PR DESCRIPTION
pafy has [support for a couple of playlist prefixes](https://github.com/mps-youtube/pafy/blob/develop/pafy/playlist.py#L23) that are not recognized by mps-youtube, so this PR adds them to the `pl` command regex. Note that OL prefixes are actually not supported by pafy without https://github.com/mps-youtube/pafy/pull/226.