### PR TITLE
Fix stream_details and player.play to reflect changes in override [Fixes #812]

### DIFF
--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -72,9 +72,10 @@ class BasePlayer:
                 lastfm.set_now_playing(g.artist, g.scrobble_queue[self.song_no])
 
             try:
-                self.video, self.stream = stream_details(self.song,
-                                                         override=self.override,
-                                                         softrepeat=self.softrepeat)
+                self.video, self.stream, self.override = stream_details(
+                                                            self.song,
+                                                            override=self.override,
+                                                            softrepeat=self.softrepeat)
                 self._playsong()
 
             except KeyboardInterrupt:
@@ -362,7 +363,7 @@ def stream_details(song, failcount=0, override=False, softrepeat=False):
         if not stream:
             raise IOError("No streams available")
 
-        return (video, stream)
+        return (video, stream, override)
 
     except (HTTPError) as e:
 


### PR DESCRIPTION
This fixes the issue of live steams playing video, regardless of the show_video setting, at least for mpv.
It should also work for any other player that implements that check correctly.

Makes the following check actually work https://github.com/mps-youtube/mps-youtube/blob/881dfe74a67ad6c2c6b3be480557d8894d330973/mps_youtube/players/mpv.py#L68 

Fixes #812