### PR TITLE
use json format for config file

### DIFF
--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -3,6 +3,7 @@ import re
 import sys
 import copy
 import pickle
+import json
 from urllib.request import urlopen
 from urllib.error import HTTPError
 from urllib.parse import urlencode
@@ -371,17 +372,28 @@ class _Config:
         """ Save current config to file. """
         config = {setting: self[setting].value for setting in self}
 
-        with open(g.CFFILE, "wb") as cf:
-            pickle.dump(config, cf, protocol=2)
+        with open(g.CFFILE, "w") as cf:
+            json.dump(config, cf, indent=2)
 
         util.dbg(c.p + "Saved config: " + g.CFFILE + c.w)
+
+    def convert_old_cf_to_json(self):
+        """
+        check if old-style config exists,
+        convert old-style pickled binary config to json and save to disk,
+        delete old-style config
+        """
+        if os.path.exists(g.OLD_CFFILE):
+            with open(g.OLD_CFFILE, "rb") as cf:
+                with open(g.CFFILE, "w") as cfj:
+                    json.dump(pickle.load(cf), cfj, indent=2)
+            os.remove(g.OLD_CFFILE)
 
     def load(self):
         """ Override config if config file exists. """
         if os.path.exists(g.CFFILE):
-
-            with open(g.CFFILE, "rb") as cf:
-                saved_config = pickle.load(cf)
+            with open(g.CFFILE, "r") as cf:
+                saved_config = json.load(cf)
 
             for k, v in saved_config.items():
 

--- a/mps_youtube/g.py
+++ b/mps_youtube/g.py
@@ -50,7 +50,8 @@ streams = collections.OrderedDict()
 pafy_pls = {}  #
 last_opened = message = content = ""
 suffix = "3" # Python 3
-CFFILE = os.path.join(paths.get_config_dir(), "config")
+OLD_CFFILE = os.path.join(paths.get_config_dir(), "config")
+CFFILE = os.path.join(paths.get_config_dir(), "config.json")
 TCFILE = os.path.join(paths.get_config_dir(), "transcode")
 OLD_PLFILE = os.path.join(paths.get_config_dir(), "playlist" + suffix)
 PLFILE = os.path.join(paths.get_config_dir(), "playlist_v2")

--- a/mps_youtube/init.py
+++ b/mps_youtube/init.py
@@ -41,6 +41,9 @@ def init():
     suffix = ".exe" if mswin else ""
     mplayer, mpv = "mplayer" + suffix, "mpv" + suffix
 
+    # check for old pickled binary config and convert to json if so
+    config.convert_old_cf_to_json()
+
     if not os.path.exists(g.CFFILE):
 
         if has_exefile(mpv):


### PR DESCRIPTION
This PR replaces the config file format with human-friendly JSON, and also adds code to seamlessly convert old configs to JSON if detected.

---

## rationale

As the recent API key overload made clear (issue #551), users being able to edit the config themselves is an important feature (modifying the configured default API key is not really feasible by hand, as one user remarked).

The config is currently stored as a pickled binary file, which is not user-friendly.

Pickled binary storage is not necessary for any reasonable disk-space reasons. The difference in the old config style vs json is on the order of tens of bytes, as can be seen:

```
pi@raspberrypi:~/.config/mps-youtube $ python3

>>> import pickle
>>> import json
>>> with open('config', 'rb') as cf:
...     with open('config.json', 'w') as cfj:
...             json.dump(pickle.load(cf), cfj)
... 
>>> 
KeyboardInterrupt

pi@raspberrypi:~/.config/mps-youtube $ ls -l
total 20
-rw-r--r-- 1 pi pi  708 Jul 15 03:14 config
-rw-r--r-- 1 pi pi  676 Jul 15 03:47 config.json
```

Signed-off-by: dt-rush <nickp@balena.io>