### PR TITLE
Misalignment due to East East Asian chars fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ pafy
 vi.py
 MANIFEST
 .dev
+.vscode
 # Packages
 *.egg
 *.egg-info

--- a/mps_youtube/content.py
+++ b/mps_youtube/content.py
@@ -124,15 +124,14 @@ def generate_songlist_display(song=False, zeromsg=None):
         cat = details.get('category') or '-'
         details['category'] = pafy.get_categoryname(cat)
         details['ytid'] = x.ytid
-        data = []
+        line = ''
 
         for z in columns:
-            fieldsize, field = z['size'], z['name']
-            if len(details[field]) > fieldsize:
-                details[field] = details[field][:fieldsize]
-            data.append(details[field])
+            fieldsize, field, direction = z['size'], z['name'], "<" if z['sign'] == "-" else ">"
+            line += uea_pad(fieldsize, details[field], direction)
+            if not columns[-1] == z:
+                line += "  "
 
-        line = fmtrow % tuple(data)
         col = col if not song or song != g.model[n] else c.p
         line = col + line + c.w
         out += line + "\n"

--- a/mps_youtube/listview/__init__.py
+++ b/mps_youtube/listview/__init__.py
@@ -114,21 +114,26 @@ class ListView(content.PaginatedContent):
 
         for num, obj in enumerate(self.objects[self._page_slice()]):
             col = (c.r if num % 2 == 0 else c.p)
+            idx = num + (self.views_per_page() * self.page) + 1
 
-            data = []
+            line = ''
             for column in self.columns:
                 fieldsize, field = column['size'], column['name']
+                direction = "<" if column['sign'] == "-" else ">"
+
                 if field == "idx":
-                    data.append("%2d" % (num + (self.views_per_page() * self.page) + 1))
+                    field = "%2d" % idx
+
                 else:
                     field = getattr(obj, field)(fieldsize)
                     field = str(field) if field.__class__ != str else field
-                    if len(field) > fieldsize:
-                        field = field[:fieldsize]
-                    else:
-                        field = field + (" " * (fieldsize - len(field)))
-                    data.append(field)
-            line = col + (fmtrow % tuple(data)) + c.w
+
+                line += util.uea_pad(fieldsize, field, direction)
+
+                if column != self.columns[-1]:
+                    line += "  "
+
+            line = col + line + c.w
             out += line + "\n"
         
         return out

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -259,6 +259,21 @@ def fmt_time(seconds):
 
     return hms
 
+def correct_truncate(text, max_len):
+    """ Truncate a string taking into account East Asian width chars."""
+    str_len, out = 0, ''
+
+    for c in text:
+        str_len += real_len(c)
+
+        if str_len <= max_len:
+            out += c
+
+        else:
+            break
+
+    return out
+
 
 def uea_pad(num, t, direction="<", notrunc=False):
     """ Right pad with spaces taking into account East Asian width chars. """

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -287,7 +287,7 @@ def uea_pad(num, t, direction="<", notrunc=False):
 
     if not notrunc:
         # Truncate to max of num characters
-        t = t[:num]
+        t = correct_truncate(t, num)
 
     if real_len(t) < num:
         spaces = num - real_len(t)


### PR DESCRIPTION
Due to East East Asian chars being more than two columns wide on terminal, video list often was misaligned and looked like this:

![mps_yt_1](https://user-images.githubusercontent.com/46261165/61957739-9d5dc900-afc8-11e9-8c9b-7fd4bb2a2622.png)
(Whole table doesn't even fit into the terminal window)

Added `util.correct_truncate` method which truncates a string taking into account East Asian width chars. `util.`ea_pad' now pads correctly.
Also `content.generate_songlist_display` and `ListView.content` functions now use custom string formatting instead of the default one and output correct table:

![mps_yt_2](https://user-images.githubusercontent.com/46261165/61957740-9d5dc900-afc8-11e9-9f1e-edbb54027fb0.png)

**Note:** the `util.real_len` function doesn't take into account Unicode emojis. Because of that, the table is still a bit misaligned (line 12 & 20). 
I suggest to let [wcwidth](https://github.com/jquast/wcwidth) in `real_len` function take care of it, it should solve the problem. If the additional dependency is okay.
