### PR TITLE
Filename sanitation fix (#1009)

### DIFF
--- a/mps_youtube/commands/download.py
+++ b/mps_youtube/commands/download.py
@@ -195,7 +195,8 @@ def down_plist(dltype, parturl):
     plist(parturl)
     dump(False)
     title = g.pafy_pls[parturl][0].title
-    subdir = util.mswinfn(title.replace("/", "-"))
+    # Remove double quotes for convenience
+    subdir = util.sanitize_filename(title.replace('"', ''))
     down_many(dltype, "1-", subdir=subdir)
     msg = g.message
     plist(parturl)
@@ -227,8 +228,9 @@ def _make_fname(song, ext=None, av=None, subdir=None):
 
     # filename = song.title[:59] + "." + ext
     filename = song.title + "." + ext
-    filename = os.path.join(ddir, util.mswinfn(filename.replace("/", "-")))
+    # Remove double quotes for convenience
     filename = filename.replace('"', '')
+    filename = os.path.join(ddir, util.sanitize_filename(filename))
     return filename
 
 

--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -9,6 +9,7 @@ import collections
 import unicodedata
 import urllib
 import json
+import platform
 from datetime import datetime, timezone
 
 import pafy
@@ -18,6 +19,7 @@ from .playlist import Video
 
 from importlib import import_module
 
+macos = platform.system() == "Darwin"
 
 mswin = os.name == "nt"
 not_utf8_environment = mswin or "UTF-8" not in sys.stdout.encoding
@@ -124,6 +126,18 @@ def mswinfn(filename):
 
     return filename
 
+def sanitize_filename(filename, ignore_slashes=False):
+    """ Sanitize filename """
+    if not ignore_slashes:
+        filename = filename.replace('/', '-')
+    if macos:
+        filename = filename.replace(':', '_')
+    if mswin:
+        filename = utf8_replace(filename) if not_utf8_environment else filename
+        allowed = re.compile(r'[^\\?*$\'"%&:<>|]')
+        filename = "".join(x if allowed.match(x) else "_" for x in filename)
+
+    return filename
 
 def set_window_title(title):
     """ Set terminal window title. """


### PR DESCRIPTION
Correct file sanitation.
Previously the double quotes were being remove after creating the folder, additionally the folder name itself wasn't being properly sanitized.
Fixes #1009.