### PR TITLE
Player filenames fix (#990)

### DIFF
--- a/mps_youtube/g.py
+++ b/mps_youtube/g.py
@@ -86,7 +86,9 @@ playerargs_defaults = {
         "novid": "-novideo",
         # "ignidx": "-lavfdopts o=fflags=+ignidx".split()
         "ignidx": "",
-        "geo": "-geometry"}
+        "geo": "-geometry"},
+    "vlc": {
+        "title": "--meta-title"}
     }
 argument_commands = []
 commands = []

--- a/mps_youtube/g.py
+++ b/mps_youtube/g.py
@@ -75,7 +75,7 @@ playerargs_defaults = {
     "mpv": {
         "msglevel": {"<0.4": "--msglevel=all=no:statusline=status",
                      ">=0.4": "--msg-level=all=no:statusline=status"},
-        "title": "--title",
+        "title": "--force-media-title",
         "fs": "--fs",
         "novid": "--no-video",
         "ignidx": "--demuxer-lavf-o=fflags=+ignidx",

--- a/mps_youtube/players/mplayer.py
+++ b/mps_youtube/players/mplayer.py
@@ -13,15 +13,6 @@ not_utf8_environment = mswin or "UTF-8" not in sys.stdout.encoding
 
 
 class mplayer(CmdPlayer):
-    DEFAULT_ARGS = {
-        "title": "-title",
-        "fs": "-fs",
-        "novid": "-novideo",
-        # "ignidx": "-lavfdopts o=fflags=+ignidx".split()
-        "ignidx": "",
-        "geo": "-geometry"
-    }
-
     def __init__(self, player):
         self.player = player
         self.mplayer_version = _get_mplayer_version(player)
@@ -42,7 +33,7 @@ class mplayer(CmdPlayer):
 
         args = config.PLAYERARGS.get.strip().split()
 
-        pd = self.DEFAULT_ARGS
+        pd = g.playerargs_defaults['mplayer']
         args.extend((pd["title"], '"{0}"'.format(self.song.title)))
 
         if pd['geo'] not in args:

--- a/mps_youtube/players/mpv.py
+++ b/mps_youtube/players/mpv.py
@@ -16,16 +16,6 @@ not_utf8_environment = mswin or "UTF-8" not in sys.stdout.encoding
 
 
 class mpv(CmdPlayer):
-    DEFAULT_ARGS = {
-        "msglevel": {"<0.4": "--msglevel=all=no:statusline=status",
-                     ">=0.4": "--msg-level=all=no:statusline=status"},
-        "title": "--title",
-        "fs": "--fs",
-        "novid": "--no-video",
-        "ignidx": "--demuxer-lavf-o=fflags=+ignidx",
-        "geo": "--geometry"
-    }
-
     def __init__(self, player):
         self.player = player
         self.mpv_version = _get_mpv_version(player)
@@ -49,7 +39,7 @@ class mpv(CmdPlayer):
 
         args = config.PLAYERARGS.get.strip().split()
 
-        pd = self.DEFAULT_ARGS
+        pd = g.playerargs_defaults['mpv']
         args.extend((pd["title"], '"{0}"'.format(self.song.title)))
 
         if pd['geo'] not in args:

--- a/mps_youtube/players/vlc.py
+++ b/mps_youtube/players/vlc.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from .. import config, util
+from .. import config, util, g
 
 from ..player import CmdPlayer
 
@@ -12,6 +12,9 @@ class vlc(CmdPlayer):
 
     def _generate_real_playerargs(self):
         args = config.PLAYERARGS.get.strip().split()
+
+        pd = g.playerargs_defaults['vlc']
+        args.extend((pd["title"], '"{0}"'.format(self.song.title)))
 
         util.list_update("--play-and-exit", args)
 


### PR DESCRIPTION
_Mpv_ now shows correct video title inside the player, and _vlc_ window title matches video name too.
Also global player default arguments are used now.
Fixes #990