### PR TITLE
Adding subtitle support via workaround

### DIFF
--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -5,6 +5,7 @@ import traceback
 from urllib.request import urlopen
 from urllib.error import HTTPError, URLError
 from .. import player
+import os
 
 try:
     # pylint: disable=F0401
@@ -179,6 +180,29 @@ def clipcopy_video(num):
         g.message = "pyperclip module must be installed for clipboard support\n"
         g.message += "see https://pypi.python.org/pypi/pyperclip/"
         g.content = generate_songlist_display()
+
+
+@command(r'm\s*(\d+)')
+def open_in_mpv(num):
+    """ Feed video/playlist url to mpv. """
+    if g.browse_mode == "ytpl":
+
+        p = g.ytpls[int(num) - 1]
+        link = "https://youtube.com/playlist?list=%s" % p['link']
+
+    elif g.browse_mode == "normal":
+        item = (g.model[int(num) - 1])
+        link = "https://youtube.com/watch?v=%s" % item.ytid
+
+    else:
+        g.message = "mpv open not valid in this mode"
+        g.content = generate_songlist_display()
+        return
+
+    os.system("mpv " + link)
+    g.message = "mpv opened. If not, make sure you have it installed"
+    g.content = generate_songlist_display()
+
 
 
 @command(r'X\s*(\d+)', 'X')

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -26,6 +26,7 @@ def helptext():
         {2}r <number>{1} - show videos related to video <number>
         {2}u <number>{1} - show videos uploaded by uploader of video <number>
         {2}x <number>{1} - copy item <number> url to clipboard (requires pyperclip)
+        {2}m <number>{1} - feed item <number> url to mpv player (requires mpv)
 
         {2}q{1}, {2}quit{1} - exit mpsyt
     """.format(c.ul, c.w, c.y)),


### PR DESCRIPTION
As noted in #331 and #964, there are no subtitles when opening videos with mpv through mpsyt. Since `mpv [link]` does show subtitles, the problem is likely in how mpsyt calls mpv, but I'm not sure exactly where. A temporary workaround is to add a new command, similar to the 'copy link to clipboard', except that the link goes to opening mpv directly. In the video list, typing `m <number>` will do `mpv [link]` and subtitles will now work.

This isn't the ideal solution (it imports `os`, check for whether mpv is installed is not implemented, no mplayer support), but there's hasn't been any progress on adding subtitle support, so this workaround might be useful for people at the meantime