### PR TITLE
Fix issue #1101: ValueError raises when view video information

### DIFF
--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -252,7 +252,7 @@ def video_info(num):
         item = (g.model[int(num) - 1])
         streams.get(item)
         p = util.get_pafy(item)
-        pub = datetime.strptime(str(p.published), "%Y-%m-%d %H:%M:%S")
+        pub = datetime.strptime(str(p.published), "%Y-%m-%d %H:%M:%SZ")
         pub = util.utc2local(pub)
         screen.writestatus("Fetched")
         out = c.ul + "Video Info" + c.w + "\n\n"


### PR DESCRIPTION
The `video_info()` employs [`strptime()`](https://docs.python.org/3/library/datetime.html?highlight=datetime#datetime.datetime.strptime) to parse date string, but it cannot handle the [ISO 8601](https://www.w3.org/TR/NOTE-datetime) **time zone designator** at the end of string. For now we assume there is always a 'Z' time zone designator thus add 'Z' in the `strptime()` format string.

fix issue: #1101 