### PR TITLE
Fix issue #1103: Make MPRIS process error message more descriptive

### DIFF
--- a/mps_youtube/mpris.py
+++ b/mps_youtube/mpris.py
@@ -555,8 +555,9 @@ def main(connection):
         return
     try:
         mprisctl.acquire()
-    except dbus.exceptions.DBusException:
-        print('mpris interface couldn\'t be initialized. Is dbus properly configured?')
+    except dbus.exceptions.DBusException as e:
+        print('mpris interface couldn\'t be initialized. reason: %s'
+               % e.get_dbus_message())
         return
     mprisctl.run(connection)
     mprisctl.release()


### PR DESCRIPTION
When MPRIS process exited abnormally, show the exact reason if we cannot successfully setup dbus.

fix issue: #1103