### PR TITLE
use dict.get("foo") instead of dict["foo"]

### DIFF
--- a/mps_youtube/players/mpv.py
+++ b/mps_youtube/players/mpv.py
@@ -185,7 +185,7 @@ class mpv(CmdPlayer):
                         observe_full = True
 
                     if resp.get('event') == 'property-change' and resp['id'] == 1:
-                        if resp['data'] is not None:
+                        if resp.get('data') is not None:
                             elapsed_s = int(resp['data'])
 
                     elif resp.get('event') == 'property-change' and resp['id'] == 2:


### PR DESCRIPTION
In order to prevent following catastrophic error that I often encounter.

```
Traceback (most recent call last):                                                                                                                                                                             
  File "/usr/bin/mpsyt", line 33, in <module>
    sys.exit(load_entry_point('mps-youtube==0.2.8', 'console_scripts', 'mpsyt')())
  File "/usr/lib/python3.9/site-packages/mps_youtube/main.py", line 153, in main
    if matchfunction(i.function, i.regex, userinput):
  File "/usr/lib/python3.9/site-packages/mps_youtube/main.py", line 70, in matchfunction
    func(*matches)
  File "/usr/lib/python3.9/site-packages/mps_youtube/commands/play.py", line 121, in play_all
    play(options, "1-" + str(len(g.model)))
  File "/usr/lib/python3.9/site-packages/mps_youtube/commands/play.py", line 102, in play
    g.PLAYER_OBJ.play(songlist, shuffle, repeat, override)
  File "/usr/lib/python3.9/site-packages/mps_youtube/player.py", line 79, in play
    self._playsong()
  File "/usr/lib/python3.9/site-packages/mps_youtube/player.py", line 138, in _playsong
    self._launch_player()
  File "/usr/lib/python3.9/site-packages/mps_youtube/player.py", line 298, in _launch_player
    self.launch_player(cmd)
  File "/usr/lib/python3.9/site-packages/mps_youtube/players/mpv.py", line 135, in launch_player
    self._player_status(self.songdata + "; ", self.song.length)
  File "/usr/lib/python3.9/site-packages/mps_youtube/players/mpv.py", line 188, in _player_status
    if resp['data'] is not None:
KeyError: 'data'
```